### PR TITLE
Cache apt packages in CI

### DIFF
--- a/.github/apt-packages.txt
+++ b/.github/apt-packages.txt
@@ -1,0 +1,10 @@
+build-essential
+cmake
+qtbase5-dev
+qttools5-dev
+qttools5-dev-tools
+libqt5opengl5-dev
+libeigen3-dev
+libopenbabel-dev
+zlib1g-dev
+libglu1-mesa-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Cache apt packages
+      uses: actions/cache@v3
+      with:
+        path: /var/cache/apt/archives
+        key: ${{ runner.os }}-apt-${{ hashFiles('.github/apt-packages.txt') }}
+        restore-keys: ${{ runner.os }}-apt-
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake qtbase5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libeigen3-dev libopenbabel-dev zlib1g-dev libglu1-mesa-dev
+        sudo xargs -a .github/apt-packages.txt apt-get install -y
     - name: Configure
       run: |
         cmake -S . -B build \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Cache apt packages
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/apt/archives
+          key: ${{ runner.os }}-apt-${{ hashFiles('.github/apt-packages.txt') }}
+          restore-keys: ${{ runner.os }}-apt-
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake qtbase5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libeigen3-dev libopenbabel-dev zlib1g-dev libglu1-mesa-dev
+          sudo xargs -a .github/apt-packages.txt apt-get install -y
       - name: Configure
         run: cmake -S . -B build
       - name: Build

--- a/.github/workflows/module-build.yml
+++ b/.github/workflows/module-build.yml
@@ -12,10 +12,16 @@ jobs:
       matrix: ${{ steps.gen.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3
+      - name: Cache apt packages
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/apt/archives
+          key: ${{ runner.os }}-apt-${{ hashFiles('.github/apt-packages.txt') }}
+          restore-keys: ${{ runner.os }}-apt-
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake qtbase5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libeigen3-dev libopenbabel-dev zlib1g-dev libglu1-mesa-dev
+          sudo xargs -a .github/apt-packages.txt apt-get install -y
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
       - id: gen
@@ -38,10 +44,16 @@ jobs:
       matrix: ${{ fromJson(needs.generate-targets.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
+      - name: Cache apt packages
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/apt/archives
+          key: ${{ runner.os }}-apt-${{ hashFiles('.github/apt-packages.txt') }}
+          restore-keys: ${{ runner.os }}-apt-
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake qtbase5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libeigen3-dev libopenbabel-dev zlib1g-dev libglu1-mesa-dev
+          sudo xargs -a .github/apt-packages.txt apt-get install -y
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
       - name: Build


### PR DESCRIPTION
## Summary
- add package manifest for apt dependencies
- cache apt downloads during CI

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y build-essential cmake qtbase5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libeigen3-dev libopenbabel-dev zlib1g-dev libglu1-mesa-dev`
- `cmake ..`
- `make` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684e9ebeca4883338557c098ffa33d20