### PR TITLE
Fix compilation includes

### DIFF
--- a/libavogadro/src/extensions/crystallography/crystallographyextension.cpp
+++ b/libavogadro/src/extensions/crystallography/crystallographyextension.cpp
@@ -65,6 +65,7 @@
 #include <QTableView>
 #include <QStandardItemModel>
 #include <QScrollBar>
+#include <QHeaderView>
 
 #include <QtCore/QDebug>
 #include <QtCore/QSettings>

--- a/libavogadro/src/extensions/spectra/nmr.cpp
+++ b/libavogadro/src/extensions/spectra/nmr.cpp
@@ -25,6 +25,7 @@
 
 #include <openbabel/mol.h>
 #include <openbabel/generic.h>
+#include <openbabel/atom.h>
 #include <openbabel/obiter.h>
 #include <openbabel/elements.h>
 

--- a/libavogadro/src/extensions/surfaces/orbitalextension.cpp
+++ b/libavogadro/src/extensions/surfaces/orbitalextension.cpp
@@ -44,6 +44,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QMessageBox>
+#include <QAction>
 
 using OpenQube::BasisSet;
 using OpenQube::GaussianSet;


### PR DESCRIPTION
## Summary
- add QHeaderView include for crystallographyextension
- include QAction in orbitalextension
- include OBAtom header for nmr spectra

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Release`
- `make -j$(nproc)` *(fails: missing includes further in build)*

------
https://chatgpt.com/codex/tasks/task_e_684ecf660c88833382282058b146304c