### PR TITLE
Fix build warnings

### DIFF
--- a/libavogadro/src/engines/cartoonmeshgenerator.cpp
+++ b/libavogadro/src/engines/cartoonmeshgenerator.cpp
@@ -311,7 +311,7 @@ namespace Avogadro {
   {
     if (lis.size () > 2) {
       std::vector<Eigen::Vector3f> ilist, out;
-      Eigen::Vector3f lasti;
+      Eigen::Vector3f lasti = Eigen::Vector3f::Zero();
       for (unsigned int i = 1; i < lis.size () -1; i++) {
         Eigen::Vector3f i1, i2;
         interpolate(lis[i-1], lis[i], lis[i+1], i1, i2);

--- a/libavogadro/src/extensions/animationdialog.h
+++ b/libavogadro/src/extensions/animationdialog.h
@@ -36,7 +36,7 @@ namespace Avogadro
 
     public:
       //! Constructor
-      explicit AnimationDialog( QWidget *parent = 0, Qt::WindowFlags f = 0 );
+      explicit AnimationDialog( QWidget *parent = 0, Qt::WindowFlags f = {} );
       //! Desconstructor
       ~AnimationDialog();
 

--- a/libavogadro/src/extensions/conformersearchdialog.h
+++ b/libavogadro/src/extensions/conformersearchdialog.h
@@ -41,7 +41,7 @@ namespace Avogadro
 
     public:
       //! Constructor
-      explicit ConformerSearchDialog( QWidget *parent = 0, Qt::WindowFlags f = 0 );
+      explicit ConformerSearchDialog( QWidget *parent = 0, Qt::WindowFlags f = {} );
       //! Desconstructor
       ~ConformerSearchDialog();
 

--- a/libavogadro/src/extensions/constraintsdialog.h
+++ b/libavogadro/src/extensions/constraintsdialog.h
@@ -39,7 +39,7 @@ namespace Avogadro
 
     public:
       //! Constructor
-      explicit ConstraintsDialog( QWidget *parent = 0, Qt::WindowFlags f = 0 );
+      explicit ConstraintsDialog( QWidget *parent = 0, Qt::WindowFlags f = {} );
       //! Desconstructor
       ~ConstraintsDialog();
 

--- a/libavogadro/src/extensions/forcefielddialog.h
+++ b/libavogadro/src/extensions/forcefielddialog.h
@@ -36,7 +36,7 @@ namespace Avogadro
 
     public:
       //! Constructor
-      explicit ForceFieldDialog( QWidget *parent = 0, Qt::WindowFlags f = 0 );
+      explicit ForceFieldDialog( QWidget *parent = 0, Qt::WindowFlags f = {} );
       //! Desconstructor
       ~ForceFieldDialog();
 

--- a/libavogadro/src/extensions/insertfragmentdialog.h
+++ b/libavogadro/src/extensions/insertfragmentdialog.h
@@ -44,7 +44,7 @@ namespace Avogadro {
 
   public:
     //! Constructor
-    explicit InsertFragmentDialog(QWidget *parent = 0, QString directory = "fragments", Qt::WindowFlags f = 0);
+    explicit InsertFragmentDialog(QWidget *parent = 0, QString directory = "fragments", Qt::WindowFlags f = {});
     //! Destructor
     ~InsertFragmentDialog();
 

--- a/libavogadro/src/extensions/orca/orcaanalysedialog.h
+++ b/libavogadro/src/extensions/orca/orcaanalysedialog.h
@@ -55,7 +55,7 @@ class OrcaAnalyseDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit OrcaAnalyseDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit OrcaAnalyseDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     virtual ~OrcaAnalyseDialog();
 
 

--- a/libavogadro/src/extensions/orca/orcainputdialog.h
+++ b/libavogadro/src/extensions/orca/orcainputdialog.h
@@ -48,7 +48,7 @@ namespace Avogadro {
     Q_OBJECT
 
   public:
-    explicit OrcaInputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit OrcaInputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     virtual ~OrcaInputDialog();
 
         void setMolecule(Molecule *molecule);

--- a/libavogadro/src/extensions/orca/orcaspectra.h
+++ b/libavogadro/src/extensions/orca/orcaspectra.h
@@ -38,7 +38,7 @@ class OrcaSpectra : public QDialog
   Q_OBJECT
 
 public:
-    OrcaSpectra(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    OrcaSpectra(QWidget *parent = 0, Qt::WindowFlags f = {} );
 
 public slots:
 

--- a/libavogadro/src/extensions/povraydialog.h
+++ b/libavogadro/src/extensions/povraydialog.h
@@ -43,7 +43,7 @@ namespace Avogadro
   Q_OBJECT
 
   public:
-    explicit POVRayDialog(QWidget* parent = 0, Qt::WindowFlags f = 0);
+    explicit POVRayDialog(QWidget* parent = 0, Qt::WindowFlags f = {});
     ~POVRayDialog();
 
     /**

--- a/libavogadro/src/extensions/quantuminput/abinitinputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/abinitinputdialog.h
@@ -40,7 +40,7 @@ namespace Avogadro
     Q_OBJECT
 
   public:
-    explicit AbinitInputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit AbinitInputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     ~AbinitInputDialog();
 
     void setMolecule(Molecule *molecule);

--- a/libavogadro/src/extensions/quantuminput/daltoninputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/daltoninputdialog.h
@@ -21,7 +21,7 @@ namespace Avogadro
     Q_OBJECT
 
   public:
-    explicit DaltonInputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit DaltonInputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     ~DaltonInputDialog();
 
     void setMolecule(Molecule *molecule);

--- a/libavogadro/src/extensions/quantuminput/gamessefpmatchdialog.h
+++ b/libavogadro/src/extensions/quantuminput/gamessefpmatchdialog.h
@@ -48,7 +48,7 @@ namespace Avogadro
       };
 
       explicit GamessEfpMatchDialog(QAbstractItemModel *model, Type = EFPType,
-                           QWidget *parent = 0, Qt::WindowFlags f = 0);
+                           QWidget *parent = 0, Qt::WindowFlags f = {});
 
       ~GamessEfpMatchDialog();
 

--- a/libavogadro/src/extensions/quantuminput/gamessinputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/gamessinputdialog.h
@@ -40,7 +40,7 @@ namespace Avogadro
 
     public:
       //! Constructor
-      explicit GamessInputDialog( GamessInputData *inputData, QWidget *parent = 0, Qt::WindowFlags f = 0 );
+      explicit GamessInputDialog( GamessInputData *inputData, QWidget *parent = 0, Qt::WindowFlags f = {} );
       //! Desconstructor
       ~GamessInputDialog();
 

--- a/libavogadro/src/extensions/quantuminput/gamessukinputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/gamessukinputdialog.h
@@ -38,7 +38,7 @@ namespace Avogadro
   Q_OBJECT
 
   public:
-    explicit GAMESSUKInputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit GAMESSUKInputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     ~GAMESSUKInputDialog();
 
     void setMolecule(Molecule *molecule);

--- a/libavogadro/src/extensions/quantuminput/gaussianinputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/gaussianinputdialog.h
@@ -40,7 +40,7 @@ namespace Avogadro
     Q_OBJECT
 
   public:
-    explicit GaussianInputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit GaussianInputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     ~GaussianInputDialog();
 
     void setMolecule(Molecule *molecule);

--- a/libavogadro/src/extensions/quantuminput/inputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/inputdialog.h
@@ -36,7 +36,7 @@ namespace Avogadro
   {
   Q_OBJECT
   public:
-    explicit InputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit InputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     virtual ~InputDialog();
 
     // TODO: other enums also must be shared

--- a/libavogadro/src/extensions/quantuminput/lammpsinputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/lammpsinputdialog.h
@@ -38,7 +38,7 @@ namespace Avogadro
     Q_OBJECT
 
     public:
-      explicit LammpsInputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+      explicit LammpsInputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
       ~LammpsInputDialog();
 
       void readSettings(QSettings&);

--- a/libavogadro/src/extensions/quantuminput/molproinputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/molproinputdialog.h
@@ -36,7 +36,7 @@ namespace Avogadro
   Q_OBJECT
 
   public:
-    explicit MolproInputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit MolproInputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     ~MolproInputDialog();
 
     void setMolecule(Molecule *molecule);

--- a/libavogadro/src/extensions/quantuminput/mopacinputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/mopacinputdialog.h
@@ -42,7 +42,7 @@ namespace Avogadro
   Q_OBJECT
 
   public:
-    explicit MOPACInputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit MOPACInputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     ~MOPACInputDialog();
 
     void setMolecule(Molecule *molecule);

--- a/libavogadro/src/extensions/quantuminput/nwcheminputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/nwcheminputdialog.h
@@ -37,7 +37,7 @@ namespace Avogadro
   Q_OBJECT
 
   public:
-    explicit NWChemInputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit NWChemInputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     ~NWChemInputDialog();
 
     void setMolecule(Molecule *molecule);

--- a/libavogadro/src/extensions/quantuminput/psi4inputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/psi4inputdialog.h
@@ -37,7 +37,7 @@ namespace Avogadro
   Q_OBJECT
 
   public:
-    explicit Psi4InputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit Psi4InputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     ~Psi4InputDialog();
 
     void setMolecule(Molecule *molecule);

--- a/libavogadro/src/extensions/quantuminput/qcheminputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/qcheminputdialog.h
@@ -36,7 +36,7 @@ namespace Avogadro
   Q_OBJECT
 
   public:
-    explicit QChemInputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit QChemInputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     ~QChemInputDialog();
 
     void setMolecule(Molecule *molecule);

--- a/libavogadro/src/extensions/quantuminput/teracheminputdialog.h
+++ b/libavogadro/src/extensions/quantuminput/teracheminputdialog.h
@@ -37,7 +37,7 @@ namespace Avogadro
   Q_OBJECT
 
   public:
-    explicit TeraChemInputDialog(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit TeraChemInputDialog(QWidget *parent = 0, Qt::WindowFlags f = {} );
     ~TeraChemInputDialog();
 
     void setMolecule(Molecule *molecule);

--- a/libavogadro/src/extensions/spectra/spectradialog.h
+++ b/libavogadro/src/extensions/spectra/spectradialog.h
@@ -59,7 +59,7 @@ namespace Avogadro {
     Q_OBJECT
 
   public:
-    explicit SpectraDialog( QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit SpectraDialog( QWidget *parent = 0, Qt::WindowFlags f = {} );
     ~SpectraDialog();
 
     void setMolecule(Molecule *molecule);

--- a/libavogadro/src/extensions/spectra/vibrationwidget.h
+++ b/libavogadro/src/extensions/spectra/vibrationwidget.h
@@ -42,7 +42,7 @@ namespace Avogadro {
 
     public:
       //! Constructor
-      explicit VibrationWidget( QWidget *parent = 0, Qt::WindowFlags f = 0 );
+      explicit VibrationWidget( QWidget *parent = 0, Qt::WindowFlags f = {} );
       //! Deconstructor
       ~VibrationWidget();
 

--- a/libavogadro/src/extensions/supercelldialog.h
+++ b/libavogadro/src/extensions/supercelldialog.h
@@ -31,7 +31,7 @@ namespace Avogadro
   Q_OBJECT
 
   public:
-    explicit SuperCellDialog( QWidget *parent = 0, Qt::WindowFlags f = 0 );
+    explicit SuperCellDialog( QWidget *parent = 0, Qt::WindowFlags f = {} );
     ~SuperCellDialog();
 
     int aCells();

--- a/libavogadro/src/extensions/surfaces/openqube/gamessukout.h
+++ b/libavogadro/src/extensions/surfaces/openqube/gamessukout.h
@@ -39,8 +39,9 @@ namespace OpenQube
 class OPENQUBE_EXPORT GUKBasisSet
 {
 public:
-  GUKBasisSet() {};
-  ~GUKBasisSet() {};
+  GUKBasisSet()
+    : nShell(0), nBasisFunctions(0), nElectrons(0) {}
+  ~GUKBasisSet() {}
 
   void outputCoord();
   void outputBasis();

--- a/libavogadro/src/extensions/surfaces/openqube/gamessus.cpp
+++ b/libavogadro/src/extensions/surfaces/openqube/gamessus.cpp
@@ -66,7 +66,7 @@ void GAMESSUSOutput::processLine(GaussianSet *basis)
   if (m_in->atEnd())
     return;
 
-  QStringList list = key.split(' ', QString::SkipEmptyParts);
+  QStringList list = key.split(' ', Qt::SkipEmptyParts);
   int numGTOs;
 
   // Big switch statement checking for various things we are interested in
@@ -129,7 +129,7 @@ void GAMESSUSOutput::processLine(GaussianSet *basis)
       // should start at the first line of shell functions
       if (key.isEmpty())
         break;
-      list = key.split(' ', QString::SkipEmptyParts);
+      list = key.split(' ', Qt::SkipEmptyParts);
       numGTOs = 0;
       while (list.size() > 1) {
         numGTOs++;
@@ -162,7 +162,7 @@ void GAMESSUSOutput::processLine(GaussianSet *basis)
           m_shelltoAtom.push_back(m_currentAtom);
           numGTOs = 0;
         }
-        list = key.split(' ', QString::SkipEmptyParts);
+        list = key.split(' ', Qt::SkipEmptyParts);
       } // end "while list > 1) -- i.e., we're on the next atom line
 
       key = m_in->readLine(); // start reading the next atom
@@ -177,7 +177,7 @@ void GAMESSUSOutput::processLine(GaussianSet *basis)
         key = m_in->readLine(); // energies
         key = m_in->readLine(); // symmetries
         key = m_in->readLine(); // now we've got coefficients
-        list = key.split(' ', QString::SkipEmptyParts);
+        list = key.split(' ', Qt::SkipEmptyParts);
         unsigned int numColumns = 0;
         unsigned int numRows = 0;
         while (list.size() > 5) {
@@ -190,7 +190,7 @@ void GAMESSUSOutput::processLine(GaussianSet *basis)
           key = m_in->readLine();
           if (key.contains(QLatin1String("END OF RHF")))
             break;
-          list = key.split(' ', QString::SkipEmptyParts);
+          list = key.split(' ', Qt::SkipEmptyParts);
         } // ok, we've finished one batch of MO coeffs
 
         // Now we need to re-order the MO coeffs, so we insert one MO at a time

--- a/libavogadro/src/extensions/surfaces/openqube/gaussianfchk.cpp
+++ b/libavogadro/src/extensions/surfaces/openqube/gaussianfchk.cpp
@@ -62,7 +62,7 @@ void GaussianFchk::processLine()
   key = key.trimmed();
 
   QString tmp = line.mid(43, 37);
-  QStringList list = tmp.split(' ', QString::SkipEmptyParts);
+  QStringList list = tmp.split(' ', Qt::SkipEmptyParts);
 
   // Big switch statement checking for various things we are interested in
   if (key == "Number of atoms")
@@ -225,7 +225,7 @@ vector<int> GaussianFchk::readArrayI(unsigned int n)
     if (line.isEmpty())
       return tmp;
 
-    QStringList list = line.split(' ', QString::SkipEmptyParts);
+    QStringList list = line.split(' ', Qt::SkipEmptyParts);
     for (int i = 0; i < list.size(); ++i) {
       if (tmp.size() >= n) {
         qDebug() << "Too many variables read in. File may be inconsistent."
@@ -260,7 +260,7 @@ vector<double> GaussianFchk::readArrayD(unsigned int n, int width)
       return tmp;
 
     if (width == 0) { // we can split by spaces
-      QStringList list = line.split(' ', QString::SkipEmptyParts);
+      QStringList list = line.split(' ', Qt::SkipEmptyParts);
       for (int i = 0; i < list.size(); ++i) {
         if (tmp.size() >= n) {
           qDebug() << "Too many variables read in. File may be inconsistent."
@@ -317,7 +317,7 @@ bool GaussianFchk::readDensityMatrix(unsigned int n, int width)
       return false;
 
     if (width == 0) { // we can split by spaces
-      QStringList list = line.split(' ', QString::SkipEmptyParts);
+      QStringList list = line.split(' ', Qt::SkipEmptyParts);
       for (int k = 0; k < list.size(); ++k) {
         if (cnt >= n) {
           qDebug() << "Too many variables read in. File may be inconsistent."

--- a/libavogadro/src/extensions/surfaces/openqube/molden.cpp
+++ b/libavogadro/src/extensions/surfaces/openqube/molden.cpp
@@ -92,7 +92,7 @@ void MoldenFile::processLine(GaussianSet* basis)
   if (m_in->atEnd())
     return;
 
-  QStringList list = key.split(' ', QString::SkipEmptyParts);
+  QStringList list = key.split(' ', Qt::SkipEmptyParts);
 
   // Big switch statement checking for various things we are interested in
   // Make sure to switch mode:
@@ -140,7 +140,7 @@ void MoldenFile::processLine(GaussianSet* basis)
 
       key = m_in->readLine().trimmed();
       while (!key.isEmpty()) { // read the shell types in this GTO
-        list = key.split(' ', QString::SkipEmptyParts);
+        list = key.split(' ', Qt::SkipEmptyParts);
         shell = list[0].toLower();
         shellType = UU;
         if (shell.contains("sp"))
@@ -168,7 +168,7 @@ void MoldenFile::processLine(GaussianSet* basis)
         // now read all the exponents and contraction coefficients
         for (int gto = 0; gto < numGTOs; ++gto) {
           key = m_in->readLine().trimmed();
-          list = key.split(' ', QString::SkipEmptyParts);
+          list = key.split(' ', Qt::SkipEmptyParts);
           m_a.push_back(list[0].replace('D','E').toDouble());
           m_c.push_back(list[1].replace('D','E').toDouble());
           if (shellType == SP && list.size() > 2)
@@ -183,14 +183,14 @@ void MoldenFile::processLine(GaussianSet* basis)
       // parse occ, spin, energy, etc.
       while (!key.isEmpty() && key.contains('=')) {
         key = m_in->readLine().trimmed();
-        list = key.split(' ', QString::SkipEmptyParts);
+        list = key.split(' ', Qt::SkipEmptyParts);
         if (key.contains("occup", Qt::CaseInsensitive))
           m_electrons += (int)list[1].toDouble();
       }
 
       // parse MO coefficients
       while (!key.isEmpty() && !key.contains('=')) {
-        list = key.split(' ', QString::SkipEmptyParts);
+        list = key.split(' ', Qt::SkipEmptyParts);
         if (list.size() < 2)
           break;
 

--- a/libavogadro/src/extensions/surfaces/openqube/orca.cpp
+++ b/libavogadro/src/extensions/surfaces/openqube/orca.cpp
@@ -85,7 +85,7 @@ void ORCAOutput::processLine(GaussianSet *basis)
     if (m_in->atEnd())
         return;
 
-    QStringList list = key.split(' ', QString::SkipEmptyParts);
+    QStringList list = key.split(' ', Qt::SkipEmptyParts);
     int numGTOs;
 
     // Big switch statement checking for various things we are interested in
@@ -106,7 +106,7 @@ void ORCAOutput::processLine(GaussianSet *basis)
 
             // Number of groups of distinct atoms
             key = m_in->readLine();
-            list = key.split(' ', QString::SkipEmptyParts);
+            list = key.split(' ', Qt::SkipEmptyParts);
             if (list.size() > 3) {
                 m_nGroups = list[2].toInt();
             } else {
@@ -137,7 +137,7 @@ void ORCAOutput::processLine(GaussianSet *basis)
     } else if (key.contains("NUMBER OF CARTESIAN GAUSSIAN BASIS")) {
         m_currentMode = NotParsing; // no longer reading GTOs
     } else if (key.contains("Number of Electrons")) {
-        list = key.split(' ', QString::SkipEmptyParts);
+        list = key.split(' ', Qt::SkipEmptyParts);
         m_electrons = list[5].toInt();
     } else if (key.contains("SPIN UP ORBITALS") && !m_openShell) {
         m_openShell = true; //not yet implemented
@@ -166,15 +166,14 @@ void ORCAOutput::processLine(GaussianSet *basis)
     } else {
 
         vector <vector <double> > columns;
-        unsigned int numColumns, numRows;
-        numColumns = 0;
-        numRows = 0;
+        int numColumns = 0;
+        int numRows = 0;
         // parsing a line -- what mode are we in?
 
         switch (m_currentMode) {
         case Atoms: {
             if (key.isEmpty()) break;
-            list = key.split(' ', QString::SkipEmptyParts);
+            list = key.split(' ', Qt::SkipEmptyParts);
             while (!key.isEmpty()){
                 if (list.size() < 8) {
                     break;
@@ -186,7 +185,7 @@ void ORCAOutput::processLine(GaussianSet *basis)
                 basis->moleculeRef().addAtom(pos, int (list[2].toDouble()));
                 m_atomLabel +=list[1].trimmed();
                 key = m_in->readLine().trimmed();
-                list = key.split(' ', QString::SkipEmptyParts);
+                list = key.split(' ', Qt::SkipEmptyParts);
             }
             m_currentMode = NotParsing;
             break;
@@ -196,7 +195,7 @@ void ORCAOutput::processLine(GaussianSet *basis)
             if (key.isEmpty())
                 break;
             numGTOs = 0;
-            list = key.split(' ', QString::SkipEmptyParts);
+            list = key.split(' ', Qt::SkipEmptyParts);
             int nShells;
             // init all vectors etc.
             m_basisAtomLabel.clear();
@@ -214,7 +213,7 @@ void ORCAOutput::processLine(GaussianSet *basis)
 
                 key = m_in->readLine().trimmed();
 
-                list = key.split(' ', QString::SkipEmptyParts);
+                list = key.split(' ', Qt::SkipEmptyParts);
 
                 nShells = 0;
                 m_basisFunctions.push_back(new std::vector<std::vector<Eigen::Vector2d> *>);
@@ -230,7 +229,7 @@ void ORCAOutput::processLine(GaussianSet *basis)
                     for (int i=0;i<nFunc;i++) {
                         key = m_in->readLine().trimmed();
 
-                        list = key.split(' ', QString::SkipEmptyParts);
+  list = key.split(' ', Qt::SkipEmptyParts);
                         m_basisFunctions.at(numGTOs)->at(nShells)->at(i).x() = list[1].toDouble();          // exponent
                         m_basisFunctions.at(numGTOs)->at(nShells)->at(i).y() = list[2].toDouble();          // coeff
                     }
@@ -238,7 +237,7 @@ void ORCAOutput::processLine(GaussianSet *basis)
                     nShells++;
                     key = m_in->readLine().trimmed();
 
-                    list = key.split(' ', QString::SkipEmptyParts);
+                    list = key.split(' ', Qt::SkipEmptyParts);
                 }
                 m_orcaShellTypes.push_back(std::vector<orbital>(shellTypes.size()));
                 m_orcaShellTypes.at(numGTOs) =  shellTypes;
@@ -249,7 +248,7 @@ void ORCAOutput::processLine(GaussianSet *basis)
                 key = m_in->readLine().trimmed();
                 key = m_in->readLine().trimmed();
 
-                list = key.split(' ', QString::SkipEmptyParts);
+                list = key.split(' ', Qt::SkipEmptyParts);
                 if (list.size() == 0) break; // unexpected structure - suppose no more NewGTOs
             }
 
@@ -293,13 +292,13 @@ void ORCAOutput::processLine(GaussianSet *basis)
                 while (rx.indexIn(key) != -1){          // avoid wrong splitting
                     key.insert(rx.indexIn(key)+1, " ");
                 }
-                list = key.split(' ', QString::SkipEmptyParts);
+                list = key.split(' ', Qt::SkipEmptyParts);
 
                 numColumns = list.size() - 2;
                 columns.resize(numColumns);
                 while (list.size() > 2) {
                     orcaOrbitals += list[1];
-                    for (unsigned int i = 0; i < numColumns; ++i) {
+                    for (int i = 0; i < numColumns; ++i) {
                         columns[i].push_back(list[i + 2].toDouble());
                     }
 
@@ -308,7 +307,7 @@ void ORCAOutput::processLine(GaussianSet *basis)
                         key.insert(rx.indexIn(key)+1, " ");
                     }
 
-                    list = key.split(' ', QString::SkipEmptyParts);
+                    list = key.split(' ', Qt::SkipEmptyParts);
                     if (list.size() != numColumns+2)
                         break;
 
@@ -317,11 +316,11 @@ void ORCAOutput::processLine(GaussianSet *basis)
                 int idx = 0;
                 while (idx<orcaOrbitals.size()){
                     if (orcaOrbitals.at(idx).contains("pz")) {
-                        for (uint i=0;i<numColumns;i++){
+                        for (int i = 0; i < numColumns; ++i){
                             qSwap (columns[i].at(idx),columns[i].at(idx+1));
                         }
                         idx++;
-                        for (uint i=0;i<numColumns;i++){
+                        for (int i = 0; i < numColumns; ++i){
                             qSwap (columns[i].at(idx),columns[i].at(idx+1));
                         }
                         idx++;
@@ -332,9 +331,9 @@ void ORCAOutput::processLine(GaussianSet *basis)
                 }
 
                 // Now we need to re-order the MO coeffs, so we insert one MO at a time
-                for (unsigned int i = 0; i < numColumns; ++i) {
+                for (int i = 0; i < numColumns; ++i) {
                     numRows = columns[i].size();
-                    for (unsigned int j = 0; j < numRows; ++j) {
+                    for (int j = 0; j < numRows; ++j) {
                         m_MOcoeffs.push_back(columns[i][j]);
                     }
                 }
@@ -362,13 +361,13 @@ void ORCAOutput::processLine(GaussianSet *basis)
                     while (rx.indexIn(key) != -1){          // avoid wrong splitting
                         key.insert(rx.indexIn(key)+1, " ");
                     }
-                    list = key.split(' ', QString::SkipEmptyParts);
+                    list = key.split(' ', Qt::SkipEmptyParts);
                     numColumns = list.size() - 2;
                     columns.resize(numColumns);
                     while (list.size() > 2) {
                         orcaOrbitals += list[1];
                         //                    columns.resize(numColumns);
-                        for (unsigned int i = 0; i < numColumns; ++i) {
+                        for (int i = 0; i < numColumns; ++i) {
                             columns[i].push_back(list[i + 2].toDouble());
                         }
 
@@ -376,7 +375,7 @@ void ORCAOutput::processLine(GaussianSet *basis)
                         while (rx.indexIn(key) != -1){          // avoid wrong splitting
                             key.insert(rx.indexIn(key)+1, " ");
                         }
-                        list = key.split(' ', QString::SkipEmptyParts);
+                        list = key.split(' ', Qt::SkipEmptyParts);
                         if (list.size() != numColumns+2)
                             break;
 
@@ -385,11 +384,11 @@ void ORCAOutput::processLine(GaussianSet *basis)
                     int idx = 0;
                     while (idx<orcaOrbitals.size()){
                         if (orcaOrbitals.at(idx).contains("pz")) {
-                            for (uint i=0;i<numColumns;i++){
+                        for (int i=0; i<numColumns; ++i){
                                 qSwap (columns[i].at(idx),columns[i].at(idx+1));
                             }
                             idx++;
-                            for (uint i=0;i<numColumns;i++){
+                        for (int i=0; i<numColumns; ++i){
                                 qSwap (columns[i].at(idx),columns[i].at(idx+1));
                             }
                             idx++;
@@ -400,9 +399,9 @@ void ORCAOutput::processLine(GaussianSet *basis)
                     }
 
                     // Now we need to re-order the MO coeffs, so we insert one MO at a time
-                    for (unsigned int i = 0; i < numColumns; ++i) {
-                        numRows = columns[i].size();
-                        for (unsigned int j = 0; j < numRows; ++j) {
+                for (int i = 0; i < numColumns; ++i) {
+                    numRows = columns[i].size();
+                    for (int j = 0; j < numRows; ++j) {
 
                             m_MOcoeffs.push_back(columns[i][j]);
                         }
@@ -519,8 +518,8 @@ void ORCAOutput::calculateDensityMatrix()
         for (unsigned int i = 0; i < m_numBasisFunctions; ++i)
             moMatrix.coeffRef(i, j) = m_MOcoeffs[i + j*m_numBasisFunctions];
 
-    for (int j = 0; j < m_numBasisFunctions; j++) {
-        for (int i = 0; i< m_numBasisFunctions; i++) {
+    for (unsigned int j = 0; j < m_numBasisFunctions; ++j) {
+        for (unsigned int i = 0; i < m_numBasisFunctions; ++i) {
             m_density(i,j) = 0.;
             double density = 0.;
             for (int k = 0; k < m_homo; k++) {

--- a/libavogadro/src/extensions/surfaces/orbitalsettingsdialog.h
+++ b/libavogadro/src/extensions/surfaces/orbitalsettingsdialog.h
@@ -38,7 +38,7 @@ namespace Avogadro
     Q_OBJECT
 
   public:
-    explicit OrbitalSettingsDialog(OrbitalWidget* parent, Qt::WindowFlags f = 0);
+    explicit OrbitalSettingsDialog(OrbitalWidget* parent, Qt::WindowFlags f = {});
     ~OrbitalSettingsDialog();
 
   public slots:

--- a/libavogadro/src/extensions/surfaces/orbitalwidget.h
+++ b/libavogadro/src/extensions/surfaces/orbitalwidget.h
@@ -47,7 +47,7 @@ namespace Avogadro {
       };
 
       //! Constructor
-      explicit OrbitalWidget( QWidget *parent = 0, Qt::WindowFlags f = 0 );
+      explicit OrbitalWidget( QWidget *parent = 0, Qt::WindowFlags f = {} );
       //! Deconstructor
       virtual ~OrbitalWidget();
 

--- a/libavogadro/src/extensions/surfaces/surfacedialog.h
+++ b/libavogadro/src/extensions/surfaces/surfacedialog.h
@@ -48,7 +48,7 @@ namespace Avogadro
     Q_OBJECT
 
   public:
-    explicit SurfaceDialog(QWidget* parent = 0, Qt::WindowFlags f = 0);
+    explicit SurfaceDialog(QWidget* parent = 0, Qt::WindowFlags f = {});
     ~SurfaceDialog();
     void setMOs(int num);
     void setHOMO(int num);

--- a/libavogadro/src/extensions/swcntbuilder/swcntbuilderwidget.h
+++ b/libavogadro/src/extensions/swcntbuilder/swcntbuilderwidget.h
@@ -30,8 +30,8 @@ namespace SWCNTBuilder {
 
   public:
     explicit SWCNTBuilderWidget(const QString &title,
-                                QWidget *parent = 0, Qt::WindowFlags f = 0 );
-    explicit SWCNTBuilderWidget(QWidget *parent = 0, Qt::WindowFlags f = 0 );
+                                QWidget *parent = 0, Qt::WindowFlags f = {} );
+    explicit SWCNTBuilderWidget(QWidget *parent = 0, Qt::WindowFlags f = {} );
     virtual ~SWCNTBuilderWidget();
 
     enum LengthUnit {

--- a/libavogadro/src/extensions/symmetry/libmsym/src/msym.h
+++ b/libavogadro/src/extensions/symmetry/libmsym/src/msym.h
@@ -97,7 +97,9 @@ extern "C" {
         int n;                                  // Principal
         int l;                                  // Azimuthal
         int m;                                  // Liniear combination of magnetic quantum number (e.g. 2pz = 0, 2px = 1, 2py = -1)
-        char name[8];                           // Name
+        // Allow a little extra room for naming orbitals such as
+        // "100d10+" which may exceed eight characters
+        char name[16];                          // Name
     } msym_orbital_t;
     
     

--- a/libavogadro/src/extensions/vrmldialog.h
+++ b/libavogadro/src/extensions/vrmldialog.h
@@ -43,7 +43,7 @@ namespace Avogadro
 		Q_OBJECT
 
 	public:
-		explicit VRMLDialog(QWidget* parent = 0, Qt::WindowFlags f = 0);
+		explicit VRMLDialog(QWidget* parent = 0, Qt::WindowFlags f = {});
 		~VRMLDialog();
 
 

--- a/libavogadro/src/tools/zmatrixdialog.h
+++ b/libavogadro/src/tools/zmatrixdialog.h
@@ -42,7 +42,7 @@ namespace Avogadro {
   {
     Q_OBJECT
   public:
-    explicit ZMatrixDialog(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    explicit ZMatrixDialog(QWidget *parent = 0, Qt::WindowFlags f = {});
     ~ZMatrixDialog();
 
   public slots:


### PR DESCRIPTION
## Summary
- avoid sign-compare warnings in ORCA parser
- replace deprecated QString::split calls
- use {} instead of 0 for Qt::WindowFlags

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684f2f52c6708333ba2d655dfb222371