### PR TITLE
Add Windows installer workflow

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -1,0 +1,34 @@
+name: Windows Installer
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build-installer:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          choco install -y nsis openbabel qt5 eigen cmake
+      - name: Configure
+        run: |
+          cmake -S . -B build -G "Visual Studio 17 2022" -A x64 \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCPACK_BINARY_NSIS=ON -DCPACK_BINARY_ZIP=OFF
+      - name: Build
+        run: |
+          cmake --build build --config Release
+      - name: Test
+        run: |
+          ctest --test-dir build -C Release --output-on-failure
+      - name: Package
+        run: |
+          cmake --build build --config Release --target package
+      - name: Upload installer
+        uses: actions/upload-artifact@v3
+        with:
+          name: avogadro-windows-installer
+          path: build/*.exe


### PR DESCRIPTION
## Summary
- add a Windows GitHub Action to build the NSIS installer and upload it as an artifact

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON` *(failed: build interrupted)*
- `ctest --test-dir build --output-on-failure` *(failed: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_684faad75ba48333b355c08f1f4a6379