### PR TITLE
Fix Windows build quoting for zlib path

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -23,7 +23,7 @@ jobs:
           Expand-Archive $zip -DestinationPath $env:RUNNER_TEMP
           $src = Join-Path $env:RUNNER_TEMP "zlib-$ver"
           $bld = Join-Path $src "build"
-          cmake -S $src -B $bld -A x64 -DCMAKE_INSTALL_PREFIX=$bld\install -DBUILD_SHARED_LIBS=OFF
+          cmake -S "$src" -B "$bld" -A x64 -DCMAKE_INSTALL_PREFIX="$bld\install" -DBUILD_SHARED_LIBS=OFF
           cmake --build $bld --config Release --target install --parallel 1 --verbose
           $zlibDir = Join-Path $bld "install"
           $inc = Join-Path $zlibDir "include"


### PR DESCRIPTION
## Summary
- quote the zlib CMake variables when building OpenBabel on Windows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852584884448333b75b8174a10308a8