### PR TITLE
Fix missing Qt files in installer

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -133,6 +133,9 @@ jobs:
           "-DOPENBABEL3_LIBRARY_DIRS=$env:OPENBABEL3_LIBRARY_DIRS"
       - name: Build
         run: cmake --build build --config Release --parallel 1 --verbose
+      - name: Deploy Qt libraries
+        run: |
+          windeployqt --release build/bin/Release/avogadro.exe
       - name: Test
         run: ctest --test-dir build -C Release --output-on-failure
       - name: Package


### PR DESCRIPTION
## Summary
- include Qt runtime libraries when building the Windows installer

## Testing
- `apt-get update`
- `apt-get install` of Qt build dependencies
- `cmake -S . -B build` *(fails: Qt translation updates flagged unknown languages)*
- `cmake --build build --target avogadro-app` *(fails: interrupted build)*

------
https://chatgpt.com/codex/tasks/task_e_6853a395163c8333bbfcc434455a19a0