### PR TITLE
Use NMake for Windows installer workflow

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -41,17 +41,6 @@ jobs:
           "ZLIB_INCLUDE_DIR=$inc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "ZLIB_LIBRARY_DIR=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "$zlibDir\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Debug zlib install
-        shell: pwsh
-        run: |
-          echo "ZLIB_LIBRARY=$env:ZLIB_LIBRARY"
-          echo "ZLIB_INCLUDE_DIR=$env:ZLIB_INCLUDE_DIR"
-          echo "CMAKE_PREFIX_PATH=$env:CMAKE_PREFIX_PATH"
-          if (Test-Path "$env:ZLIB_INCLUDE_DIR/zlib.h") {
-            Get-ChildItem "$env:ZLIB_INCLUDE_DIR" | Select-Object -First 5
-          } else {
-            Write-Host "Zlib headers not found"
-          }
       - name: Install Eigen
         shell: pwsh
         run: |
@@ -62,16 +51,6 @@ jobs:
           $dir = Join-Path $env:RUNNER_TEMP "eigen-$ver"
           "EIGEN3_INCLUDE_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_PREFIX_PATH=$dir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      - name: Debug Eigen variables
-        shell: pwsh
-        run: |
-          echo "EIGEN3_INCLUDE_DIR=$env:EIGEN3_INCLUDE_DIR"
-          echo "CMAKE_PREFIX_PATH=$env:CMAKE_PREFIX_PATH"
-          if (Test-Path $env:EIGEN3_INCLUDE_DIR) {
-            Get-ChildItem $env:EIGEN3_INCLUDE_DIR | Select-Object -First 5
-          } else {
-            Write-Host "Eigen include dir not found"
-          }
       - name: Build libxml2
         shell: pwsh
         run: |

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Allow Windows reserved filenames
         run: git config --system core.protectNTFS false
       - uses: actions/checkout@v4
+      - uses: ilammy/msvc-dev-cmd@v1
       - name: Install dependencies
         run: choco install -y nsis cmake --no-progress --installargs "ADD_CMAKE_TO_PATH=System"
       - name: Build zlib
@@ -23,8 +24,10 @@ jobs:
           Expand-Archive $zip -DestinationPath $env:RUNNER_TEMP
           $src = Join-Path $env:RUNNER_TEMP "zlib-$ver"
           $bld = Join-Path $src "build"
-          cmake -S "$src" -B "$bld" -A x64 -DCMAKE_INSTALL_PREFIX="$bld\install" -DBUILD_SHARED_LIBS=OFF
-          cmake --build $bld --config Release --target install --parallel 1 --verbose
+          cmake -S "$src" -B "$bld" -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$bld\install" -DBUILD_SHARED_LIBS=OFF
+          Push-Location $bld
+          nmake install
+          Pop-Location
           $zlibDir = Join-Path $bld "install"
           $inc = Join-Path $zlibDir "include"
           $lib = Join-Path $zlibDir "lib" "zlibstatic.lib"
@@ -79,8 +82,10 @@ jobs:
           $src = Join-Path $env:RUNNER_TEMP "libxml2-$ver"
           $bld = Join-Path $src 'build'
           New-Item -ItemType Directory -Path $bld | Out-Null
-          cmake -S "$src" -B "$bld" -A x64 -DCMAKE_INSTALL_PREFIX="$bld\install" -DBUILD_SHARED_LIBS=ON -DZLIB_LIBRARY="$env:ZLIB_LIBRARY" -DZLIB_INCLUDE_DIR="$env:ZLIB_INCLUDE_DIR" -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
-          cmake --build $bld --config Release --target install --parallel 1 --verbose
+          cmake -S "$src" -B "$bld" -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$bld\install" -DBUILD_SHARED_LIBS=ON -DZLIB_LIBRARY="$env:ZLIB_LIBRARY" -DZLIB_INCLUDE_DIR="$env:ZLIB_INCLUDE_DIR" -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
+          Push-Location $bld
+          nmake install
+          Pop-Location
           Write-Host "libxml2 library path after install:" (Join-Path $bld 'install')
           $xmlDir = Join-Path $bld 'install'
           $inc = Join-Path $xmlDir 'include'
@@ -105,8 +110,10 @@ jobs:
           $srcDir = Join-Path $env:RUNNER_TEMP 'openbabel-src'
           git clone --depth 1 https://github.com/thosoo/openbabel $srcDir
           $build = Join-Path $srcDir 'build'
-          cmake -S $srcDir -B $build -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$build\install" -DLIBXML2_LIBRARY="$env:LIBXML2_LIBRARY" -DLIBXML2_LIBRARIES="$env:LIBXML2_LIBRARY" -DLIBXML2_INCLUDE_DIR="$env:LIBXML2_INCLUDE_DIR" -DZLIB_LIBRARY="$env:ZLIB_LIBRARY" -DZLIB_INCLUDE_DIR="$env:ZLIB_INCLUDE_DIR" -DENABLE_TESTS=OFF -DBUILD_SHARED=ON -DCMAKE_VERBOSE_MAKEFILE=ON
-          cmake --build $build --config Release --target install --parallel 1 --verbose
+          cmake -S $srcDir -B $build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$build\install" -DLIBXML2_LIBRARY="$env:LIBXML2_LIBRARY" -DLIBXML2_LIBRARIES="$env:LIBXML2_LIBRARY" -DLIBXML2_INCLUDE_DIR="$env:LIBXML2_INCLUDE_DIR" -DZLIB_LIBRARY="$env:ZLIB_LIBRARY" -DZLIB_INCLUDE_DIR="$env:ZLIB_INCLUDE_DIR" -DENABLE_TESTS=OFF -DBUILD_SHARED=ON -DCMAKE_VERBOSE_MAKEFILE=ON
+          Push-Location $build
+          nmake install
+          Pop-Location
           $obDir = Join-Path $build 'install'
           $inc = Join-Path $obDir 'include' 'openbabel3'
           $lib = Join-Path $obDir 'lib' 'openbabel.lib'
@@ -122,7 +129,7 @@ jobs:
       - name: Configure
         shell: pwsh
         run: >
-          cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+          cmake -S . -B build -G "NMake Makefiles"
           -DCMAKE_BUILD_TYPE=Release
           -DBUILD_SHARED_LIBS=ON
           -DCMAKE_VERBOSE_MAKEFILE=ON
@@ -134,7 +141,11 @@ jobs:
           "-DOPENBABEL3_LIBRARIES=$env:OPENBABEL3_LIBRARIES"
           "-DOPENBABEL3_LIBRARY_DIRS=$env:OPENBABEL3_LIBRARY_DIRS"
       - name: Build
-        run: cmake --build build --config Release --parallel 1 --verbose
+        shell: pwsh
+        run: |
+          Push-Location build
+          nmake
+          Pop-Location
       - name: Install
         run: cmake --install build --config Release --prefix scripts/installer/dist
       - name: Deploy Qt libraries

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -30,8 +30,10 @@ jobs:
           Pop-Location
           $zlibDir = Join-Path $bld "install"
           $inc = Join-Path $zlibDir "include"
-          $lib = Join-Path $zlibDir "lib" "zlibstatic.lib"
           $libDir = Join-Path $zlibDir "lib"
+          $static = Join-Path $libDir "zlibstatic.lib"
+          $lib = Join-Path $libDir "zlib.lib"
+          Copy-Item $static $lib -Force
           "CMAKE_PREFIX_PATH=$zlibDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_INCLUDE_PATH=$inc;$env:CMAKE_INCLUDE_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_LIBRARY_PATH=$libDir;$env:CMAKE_LIBRARY_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build libxml2
         shell: pwsh
         run: |
-          $ver = '2.7.7'
+          $ver = '2.12.10'
           $zip = "$env:RUNNER_TEMP\libxml2.zip"
           Invoke-WebRequest "https://github.com/GNOME/libxml2/archive/refs/tags/v$ver.zip" -OutFile $zip
           Expand-Archive $zip -DestinationPath $env:RUNNER_TEMP

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -83,6 +83,10 @@ jobs:
           Push-Location $win32
           cscript configure.js compiler=msvc prefix=$installDir iconv=no zlib=yes include=$env:ZLIB_INCLUDE_DIR lib=$env:ZLIB_LIBRARY_DIR
           (Get-Content Makefile.msvc).Replace('/OPT:NOWIN98','').Replace('zdll.lib','zlib.lib') | Set-Content Makefile.msvc
+          $conf = Join-Path $src 'config.h'
+          if (Test-Path $conf) {
+            (Get-Content $conf) -replace '^#define snprintf.*', '// removed snprintf define' -replace '^#define vsnprintf.*', '// removed vsnprintf define' | Set-Content $conf
+          }
           nmake /f Makefile.msvc
           nmake /f Makefile.msvc install
           Pop-Location

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -73,24 +73,23 @@ jobs:
       - name: Build libxml2
         shell: pwsh
         run: |
-          $ver = '2.12.6'
+          $ver = '2.7.7'
           $zip = "$env:RUNNER_TEMP\libxml2.zip"
-          # GitLab's mirror is occasionally unreachable; use GitHub as a mirror
-          # to download libxml2. The extracted directory is libxml2-$ver.
           Invoke-WebRequest "https://github.com/GNOME/libxml2/archive/refs/tags/v$ver.zip" -OutFile $zip
           Expand-Archive $zip -DestinationPath $env:RUNNER_TEMP
           $src = Join-Path $env:RUNNER_TEMP "libxml2-$ver"
-          $bld = Join-Path $src 'build'
-          New-Item -ItemType Directory -Path $bld | Out-Null
-          cmake -S "$src" -B "$bld" -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$bld\install" -DBUILD_SHARED_LIBS=ON -DZLIB_LIBRARY="$env:ZLIB_LIBRARY" -DZLIB_INCLUDE_DIR="$env:ZLIB_INCLUDE_DIR" -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
-          Push-Location $bld
-          nmake install
+          $installDir = Join-Path $src 'install'
+          $win32 = Join-Path $src 'win32'
+          Push-Location $win32
+          cscript configure.js compiler=msvc prefix=$installDir iconv=no zlib=yes include=$env:ZLIB_INCLUDE_DIR lib=$env:ZLIB_LIBRARY_DIR
+          (Get-Content Makefile.msvc).Replace('/OPT:NOWIN98','').Replace('zdll.lib','zlib.lib') | Set-Content Makefile.msvc
+          nmake /f Makefile.msvc
+          nmake /f Makefile.msvc install
           Pop-Location
-          Write-Host "libxml2 library path after install:" (Join-Path $bld 'install')
-          $xmlDir = Join-Path $bld 'install'
-          $inc = Join-Path $xmlDir 'include'
-          $lib = Join-Path $xmlDir 'lib' 'libxml2.lib'
-          "CMAKE_PREFIX_PATH=$xmlDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "libxml2 library path after install:" $installDir
+          $inc = Join-Path $installDir 'include'
+          $lib = Join-Path $installDir 'lib' 'libxml2.lib'
+          "CMAKE_PREFIX_PATH=$installDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "LIBXML2_LIBRARY=$lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "LIBXML2_LIBRARIES=$lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "LIBXML2_INCLUDE_DIR=$inc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -24,7 +24,7 @@ jobs:
           Expand-Archive $zip -DestinationPath $env:RUNNER_TEMP
           $src = Join-Path $env:RUNNER_TEMP "zlib-$ver"
           $bld = Join-Path $src "build"
-          cmake -S "$src" -B "$bld" -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$bld\install" -DBUILD_SHARED_LIBS=OFF
+          cmake -S "$src" -B "$bld" -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$bld\install" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release
           Push-Location $bld
           nmake install
           Pop-Location


### PR DESCRIPTION
## Summary
- setup MSVC developer command prompt
- compile all dependencies and Avogadro with `nmake`

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: could not find Qt5)*
- `ctest --test-dir build` *(no tests were found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854bc0304b0833395ca0d80b1629c5f