### PR TITLE
Enable tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
         run: |
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_VERBOSE_MAKEFILE=ON
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DENABLE_TESTS=ON
       - name: Build
         run: |
           cmake --build build -- -j1 VERBOSE=1


### PR DESCRIPTION
## Summary
- run ctest with tests enabled by setting `ENABLE_TESTS=ON`

## Testing
- `ctest --test-dir build --output-on-failure` *(fails: Unable to find executable)*

------
https://chatgpt.com/codex/tasks/task_e_685561cb874883339e7bd5f1327790f3