### PR TITLE
Add dynamic CMake matrix generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ jobs:
       - name: List CMake targets
         run: |
           cmake --build build --target help > /tmp/make_help.log
-          grep -E '^\\.\\.\\.' /tmp/make_help.log | sed 's/... //' | awk '{print $1}' | sort -u > /tmp/targets.txt
+          grep -E '^\\.\\.\\.' /tmp/make_help.log | \
+            sed 's/... //' | awk '{print $1}' | \
+            grep -Ev '_autogen|_autogen_timestamp_deps|Continuous|Experimental|Nightly|^install|^package|^rebuild_cache|^clean$|^all$|^edit_cache$|^depend$|^tools$|^test$' | \
+            sort -u > /tmp/targets.txt
       - id: set-matrix
         run: |
           first=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,53 @@
 name: CI
 on: [push, pull_request]
+
 jobs:
-  build:
+  generate-matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache apt packages
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/apt/archives
+          key: ${{ runner.os }}-apt-${{ hashFiles('.github/apt-packages.txt') }}
+          restore-keys: ${{ runner.os }}-apt-
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo xargs -a .github/apt-packages.txt apt-get install -y
+      - name: Configure
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DENABLE_TESTS=ON
+      - name: List CMake targets
+        run: |
+          cmake --build build --target help > /tmp/make_help.log
+          grep -E '^\\.\\.\\.' /tmp/make_help.log | sed 's/... //' | awk '{print $1}' | sort -u > /tmp/targets.txt
+      - id: set-matrix
+        run: |
+          first=true
+          json='{"target":['
+          while IFS= read -r t; do
+            if $first; then
+              first=false
+            else
+              json+=','
+            fi
+            json+='"'$t'"'
+          done < /tmp/targets.txt
+          json+=']}'
+          echo "matrix=$json" >> $GITHUB_OUTPUT
+
+  build:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
       - name: Cache apt packages
@@ -23,7 +68,7 @@ jobs:
             -DENABLE_TESTS=ON
       - name: Build
         run: |
-          cmake --build build -- -j1 VERBOSE=1
+          cmake --build build --target ${{ matrix.target }} -- -j1 VERBOSE=1
       - name: Test
         run: |
-          ctest --test-dir build   --output-on-failure
+          ctest --test-dir build --output-on-failure


### PR DESCRIPTION
## Summary
- rebuild workflow to generate build matrix from `cmake --build ... --target help`
- run each CMake target as a separate matrix job

## Testing
- `ctest --test-dir build --output-on-failure` *(fails: could not find executables)*

------
https://chatgpt.com/codex/tasks/task_e_6855a2e1fdfc8333aa9e3f1b8f32c8bd