### PR TITLE
Fix OpenBabel3 hydrogen addition

### DIFF
--- a/libavogadro/src/molecule.cpp
+++ b/libavogadro/src/molecule.cpp
@@ -50,6 +50,7 @@
 #include <openbabel/griddata.h>
 #include <openbabel/grid.h>
 #include <openbabel/generic.h>
+#include <openbabel/obfunctions.h>
 #include <openbabel/forcefield.h>
 #include <openbabel/obiter.h>
 #include <openbabel/elements.h>
@@ -664,6 +665,8 @@ namespace Avogadro{
     OpenBabel::OBMol obmol = OBMol();
     if (a) {
       OpenBabel::OBAtom *obatom = obmol.GetAtom(a->index()+1);
+      // Ensure implicit hydrogens are assigned for standalone atoms
+      OpenBabel::OBAtomAssignTypicalImplicitHydrogens(obatom);
       // Set implicit valence for unusual elements not handled by OpenBabel
       // PR#2803076
       switch (obatom->GetAtomicNum()) {
@@ -707,8 +710,11 @@ namespace Avogadro{
       }
       obmol.AddHydrogens(obatom);
     }
-    else
+    else {
+      for (unsigned int i = 1; i <= obmol.NumAtoms(); ++i)
+        OpenBabel::OBAtomAssignTypicalImplicitHydrogens(obmol.GetAtom(i));
       obmol.AddHydrogens();
+    }
     // All new atoms in the OBMol must be the additional hydrogens
     unsigned int numberAtoms = numAtoms();
     int j = 0;


### PR DESCRIPTION
## Summary
- fix Molecule::addHydrogens when using OpenBabel 3
- update build instructions to include obfunctions

## Testing
- `cmake .. -DENABLE_TESTS=ON`
- `cmake --build . --target addremovehydrogenstest`
- `QT_QPA_PLATFORM=offscreen bin/addremovehydrogenstest`

------
https://chatgpt.com/codex/tasks/task_e_68567e47b4048333a9b105a27750426f