### PR TITLE
Fix OpenBabel3 hydrogen logic

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2,8 +2,8 @@ Requirements
 ============
  -- CMake 2.8.9 or later (3.0 or later recommended)
  -- Qt 5.0 or later
- -- OpenBabel 2.3.x or later (development version from
-  http://github.com/openbabel/openbabel is recommended)
+ -- OpenBabel 3.1 or later (development version from
+  https://github.com/openbabel/openbabel is recommended)
  -- Eigen 3.x
 
 

--- a/avogadro/src/mainwindow.cpp
+++ b/avogadro/src/mainwindow.cpp
@@ -79,6 +79,7 @@
 #include <openbabel/forcefield.h>
 #include <openbabel/elements.h>
 #include <openbabel/generic.h>
+#include <openbabel/obfunctions.h>
 
 #ifdef ENABLE_PYTHON
 #include <avogadro/pythonerror.h>
@@ -1168,6 +1169,8 @@ protected:
         // In OB-2.2.2 and later, builder will use 2D coordinates if present
         OBBuilder builder;
         builder.Build(*obMolecule);
+        for (unsigned int i = 1; i <= obMolecule->NumAtoms(); ++i)
+          OpenBabel::OBAtomAssignTypicalImplicitHydrogens(obMolecule->GetAtom(i));
         obMolecule->AddHydrogens(); // Add some hydrogens before running force field
 
         OBForceField* pFF =  OBForceField::FindForceField("MMFF94")->MakeNewInstance();

--- a/doc/index.docbook
+++ b/doc/index.docbook
@@ -155,7 +155,7 @@
                                         <listitem><para>CMake (>=2.8.9), the open-source build system</para></listitem>
                                         <listitem><para>Qt5 (>=5.0), the open-source application framework</para></listitem>
                                         <listitem><para>Eigen3, a library for linear algebra as a compile-time dependency of Avogadro</para></listitem>
-                                        <listitem><para>OpenBabel (>=2.3.0), the chemistry toolbox</para></listitem>
+                                        <listitem><para>OpenBabel (>=3.1), the chemistry toolbox</para></listitem>
 				</itemizedlist>
 					All of these programs and libraries are likely to be available through your distribution's repository.
 				</para>

--- a/libavogadro/src/extensions/hydrogensextension.cpp
+++ b/libavogadro/src/extensions/hydrogensextension.cpp
@@ -30,6 +30,7 @@
 #include <openbabel/mol.h>
 #include <openbabel/obiter.h>
 #include <openbabel/atom.h>
+#include <openbabel/obfunctions.h>
 
 #include <QAction>
 #include <QInputDialog>
@@ -140,9 +141,11 @@ namespace Avogadro {
         {
           OBMol obmol = m_molecule->OBMol();
           obmol.UnsetFlag(OB_PH_CORRECTED_MOL);
-          OBAtom *a;
-          FOR_ATOMS_OF_MOL(a, obmol)
-            a->SetFormalCharge(0.0);
+          FOR_ATOMS_OF_MOL(ai, obmol) {
+            OpenBabel::OBAtom *atom = &*ai;
+            atom->SetFormalCharge(0.0);
+            OpenBabel::OBAtomAssignTypicalImplicitHydrogens(atom);
+          }
           obmol.SetAutomaticFormalCharge(true);
           obmol.AddHydrogens(false, true, m_pH);
           m_molecule->setOBMol(&obmol);

--- a/libavogadro/src/molecule.cpp
+++ b/libavogadro/src/molecule.cpp
@@ -50,6 +50,7 @@
 #include <openbabel/griddata.h>
 #include <openbabel/grid.h>
 #include <openbabel/generic.h>
+#include <openbabel/obfunctions.h>
 #include <openbabel/forcefield.h>
 #include <openbabel/obiter.h>
 #include <openbabel/elements.h>
@@ -664,6 +665,8 @@ namespace Avogadro{
     OpenBabel::OBMol obmol = OBMol();
     if (a) {
       OpenBabel::OBAtom *obatom = obmol.GetAtom(a->index()+1);
+      // Ensure implicit hydrogens are assigned for standalone atoms
+      OpenBabel::OBAtomAssignTypicalImplicitHydrogens(obatom);
       // Set implicit valence for unusual elements not handled by OpenBabel
       // PR#2803076
       switch (obatom->GetAtomicNum()) {
@@ -707,8 +710,11 @@ namespace Avogadro{
       }
       obmol.AddHydrogens(obatom);
     }
-    else
+    else {
+      for (unsigned int i = 1; i <= obmol.NumAtoms(); ++i)
+        OpenBabel::OBAtomAssignTypicalImplicitHydrogens(obmol.GetAtom(i));
       obmol.AddHydrogens();
+    }
     // All new atoms in the OBMol must be the additional hydrogens
     unsigned int numberAtoms = numAtoms();
     int j = 0;


### PR DESCRIPTION
## Summary
- set implicit hydrogens for standalone atoms before calling `AddHydrogens`
- update hydrogens extension and main window for OpenBabel3 iterators
- document that OpenBabel 3.1 is required

## Testing
- `cmake --build . --target addremovehydrogenstest`
- `QT_QPA_PLATFORM=offscreen ./bin/addremovehydrogenstest`


------
https://chatgpt.com/codex/tasks/task_e_68567e47b4048333a9b105a27750426f