### PR TITLE
Fix windeployqt order

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -134,10 +134,11 @@ jobs:
             "-DOPENBABEL3_LIBRARY_DIRS=$env:OPENBABEL3_LIBRARY_DIRS" `
             "-DOPENBABEL_INSTALL_DIR=$env:OPENBABEL_INSTALL_DIR"
       - name: Build and package
-        # nmake package also performs the install step for packaging
+        # Build first and then run CPack directly to keep its output
         shell: pwsh
         run: |
-          cmake --build build --target package --config Release
+          cmake --build build --config Release
+          cpack --config ./CPackConfig.cmake
       - name: Test
         run: ctest --test-dir build -C Release --output-on-failure
       - name: Upload installer

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -117,13 +117,14 @@ jobs:
         shell: pwsh
         run: |
           $dist = Join-Path $pwd 'scripts/installer/dist'
+          $env:ENABLE_DEPRECATED_INSTALL_RULES = 'ON'
           cmake -S . -B build `
             -G "NMake Makefiles" `
             -DCMAKE_BUILD_TYPE=Release `
             -DBUILD_SHARED_LIBS=ON `
             -DCMAKE_VERBOSE_MAKEFILE=ON `
             -DCMAKE_INSTALL_PREFIX="$dist" `
-            -DENABLE_DEPRECATED_INSTALL_RULES=ON `
+            -DENABLE_DEPRECATED_INSTALL_RULES=$env:ENABLE_DEPRECATED_INSTALL_RULES `
             -DCPACK_BINARY_NSIS=ON `
             -DCPACK_BINARY_ZIP=OFF `
             "-DEIGEN3_INCLUDE_DIR=$env:EIGEN3_INCLUDE_DIR" `

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -136,10 +136,6 @@ jobs:
       - name: Build
         shell: pwsh
         run: cmake --build build --config Release
-      - name: Deploy Qt runtime libraries
-        shell: pwsh
-        run: |
-          windeployqt --release --dir build/bin build/bin/avogadro.exe
       - name: Package
         shell: pwsh
         run: |

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -117,14 +117,13 @@ jobs:
         shell: pwsh
         run: |
           $dist = Join-Path $pwd 'scripts/installer/dist'
-          $env:ENABLE_DEPRECATED_INSTALL_RULES = 'ON'
           cmake -S . -B build `
             -G "NMake Makefiles" `
             -DCMAKE_BUILD_TYPE=Release `
             -DBUILD_SHARED_LIBS=ON `
             -DCMAKE_VERBOSE_MAKEFILE=ON `
             -DCMAKE_INSTALL_PREFIX="$dist" `
-            -DENABLE_DEPRECATED_INSTALL_RULES=$env:ENABLE_DEPRECATED_INSTALL_RULES `
+            -DENABLE_DEPRECATED_INSTALL_RULES=ON `
             -DCPACK_BINARY_NSIS=ON `
             -DCPACK_BINARY_ZIP=OFF `
             "-DEIGEN3_INCLUDE_DIR=$env:EIGEN3_INCLUDE_DIR" `

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -134,11 +134,13 @@ jobs:
             "-DOPENBABEL3_LIBRARY_DIRS=$env:OPENBABEL3_LIBRARY_DIRS" `
             "-DOPENBABEL_INSTALL_DIR=$env:OPENBABEL_INSTALL_DIR"
       - name: Build and package
-        # Build first and then run CPack directly to keep its output
+        # Build first and then run CPack from the build directory so its output is visible
         shell: pwsh
         run: |
           cmake --build build --config Release
-          cpack --config ./CPackConfig.cmake
+          Push-Location build
+          cpack -C Release
+          Pop-Location
       - name: Test
         run: ctest --test-dir build -C Release --output-on-failure
       - name: Upload installer

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -133,11 +133,16 @@ jobs:
             "-DOPENBABEL3_LIBRARIES=$env:OPENBABEL3_LIBRARIES" `
             "-DOPENBABEL3_LIBRARY_DIRS=$env:OPENBABEL3_LIBRARY_DIRS" `
             "-DOPENBABEL_INSTALL_DIR=$env:OPENBABEL_INSTALL_DIR"
-      - name: Build and package
-        # Build first and then run CPack from the build directory so its output is visible
+      - name: Build
+        shell: pwsh
+        run: cmake --build build --config Release
+      - name: Deploy Qt runtime libraries
         shell: pwsh
         run: |
-          cmake --build build --config Release
+          windeployqt --release --dir build/bin build/bin/avogadro.exe
+      - name: Package
+        shell: pwsh
+        run: |
           Push-Location build
           cpack -C Release
           Pop-Location

--- a/README.md
+++ b/README.md
@@ -40,5 +40,9 @@ Automated Windows installer builds are generated with GitHub Actions and can be
 found in the workflow artifacts. The workflow builds OpenBabel from
 <https://github.com/openbabel/openbabel> and bundles it with Avogadro.
 
+To generate a Windows installer locally, configure with
+`-DENABLE_DEPRECATED_INSTALL_RULES=ON` so that the legacy packaging rules
+collect required libraries and run `windeployqt`.
+
 # Backers
 Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/avogadro#backer)]

--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ found in the workflow artifacts. The workflow builds OpenBabel from
 <https://github.com/openbabel/openbabel> and bundles it with Avogadro.
 
 To generate a Windows installer locally, configure with
-`-DENABLE_DEPRECATED_INSTALL_RULES=ON`.  After building the project, run
-`windeployqt --release --dir build/bin build/bin/avogadro.exe` and then
-invoke `cpack`.  The GitHub workflow performs these deployment steps
+`-DENABLE_DEPRECATED_INSTALL_RULES=ON`. After building the project, run
+`cpack` to create the installer. The install rules will invoke `windeployqt`
 automatically.
 
 # Backers

--- a/README.md
+++ b/README.md
@@ -41,11 +41,10 @@ found in the workflow artifacts. The workflow builds OpenBabel from
 <https://github.com/openbabel/openbabel> and bundles it with Avogadro.
 
 To generate a Windows installer locally, configure with
-`-DENABLE_DEPRECATED_INSTALL_RULES=ON` so that the legacy packaging rules
-collect required libraries and run `windeployqt`.  When CPack runs, it
-installs files to a temporary staging directory (e.g., under
-`_CPack_Packages`), and `windeployqt` is invoked from that location rather
-than the build tree.
+`-DENABLE_DEPRECATED_INSTALL_RULES=ON`.  After building the project, run
+`windeployqt --release --dir build/bin build/bin/avogadro.exe` and then
+invoke `cpack`.  The GitHub workflow performs these deployment steps
+automatically.
 
 # Backers
 Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/avogadro#backer)]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ found in the workflow artifacts. The workflow builds OpenBabel from
 
 To generate a Windows installer locally, configure with
 `-DENABLE_DEPRECATED_INSTALL_RULES=ON` so that the legacy packaging rules
-collect required libraries and run `windeployqt`.
+collect required libraries and run `windeployqt`.  When CPack runs, it
+installs files to a temporary staging directory (e.g., under
+`_CPack_Packages`), and `windeployqt` is invoked from that location rather
+than the build tree.
 
 # Backers
 Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/avogadro#backer)]

--- a/cmake/modules/AvoCPack.cmake
+++ b/cmake/modules/AvoCPack.cmake
@@ -15,38 +15,6 @@ if(WIN32)
   option(ENABLE_DEPRECATED_INSTALL_RULES "Should deprecated, Windows specific, install rules be enabled?" OFF)
 endif()
 if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
-  # Deploy Qt runtime libraries before collecting DLLs and other dependencies
-  get_filename_component(_qt_bin "${QT_QMAKE_EXECUTABLE}" PATH)
-  find_program(WINDEPLOYQT_EXE NAMES windeployqt windeployqt.exe
-    PATHS "${_qt_bin}" PATH_SUFFIXES bin)
-
-  if(WINDEPLOYQT_EXE)
-    install(CODE [=[
-      set(_exe "${CMAKE_INSTALL_PREFIX}/bin/avogadro.exe")
-      if(NOT EXISTS "${_exe}")
-        set(_exe "${CMAKE_INSTALL_PREFIX}/bin/Avogadro.exe")
-      endif()
-      if(EXISTS "${_exe}")
-        file(TO_NATIVE_PATH "${_exe}" _exe_native)
-        file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}/bin" _bin_native)
-        execute_process(
-          COMMAND "${WINDEPLOYQT_EXE}" --release --dir "${_bin_native}" "${_exe_native}"
-          RESULT_VARIABLE _wqt_res
-          OUTPUT_VARIABLE _wqt_out
-          ERROR_VARIABLE _wqt_out
-        )
-        message(STATUS "windeployqt output:\n${_wqt_out}")
-        if(_wqt_res)
-          message(WARNING "windeployqt failed with code ${_wqt_res}")
-        endif()
-      else()
-        message(WARNING "Executable not found for windeployqt: ${_exe}")
-      endif()
-    ]=])
-  else()
-    message(WARNING "windeployqt not found; Qt runtime libraries might be missing")
-  endif()
-
   # Set the directories to defaults if not set
 
   ##############################################
@@ -248,6 +216,37 @@ if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
 
   endif()
 
+  # Deploy Qt runtime libraries after installing the application
+  get_filename_component(_qt_bin "${QT_QMAKE_EXECUTABLE}" PATH)
+  find_program(WINDEPLOYQT_EXE NAMES windeployqt windeployqt.exe
+    PATHS "${_qt_bin}" PATH_SUFFIXES bin)
+
+  if(WINDEPLOYQT_EXE)
+    install(CODE [=[
+      set(_exe "${CMAKE_INSTALL_PREFIX}/bin/avogadro.exe")
+      if(NOT EXISTS "${_exe}")
+        set(_exe "${CMAKE_INSTALL_PREFIX}/bin/Avogadro.exe")
+      endif()
+      if(EXISTS "${_exe}")
+        file(TO_NATIVE_PATH "${_exe}" _exe_native)
+        file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}/bin" _bin_native)
+        execute_process(
+          COMMAND "${WINDEPLOYQT_EXE}" --release --dir "${_bin_native}" "${_exe_native}"
+          RESULT_VARIABLE _wqt_res
+          OUTPUT_VARIABLE _wqt_out
+          ERROR_VARIABLE _wqt_out
+        )
+        message(STATUS "windeployqt output:\n${_wqt_out}")
+        if(_wqt_res)
+          message(WARNING "windeployqt failed with code ${_wqt_res}")
+        endif()
+      else()
+        message(WARNING "Executable not found for windeployqt: ${_exe}")
+      endif()
+    ]=])
+  else()
+    message(WARNING "windeployqt not found; Qt runtime libraries might be missing")
+  endif()
 
 endif()
 

--- a/cmake/modules/AvoCPack.cmake
+++ b/cmake/modules/AvoCPack.cmake
@@ -26,15 +26,21 @@ if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
       if(NOT EXISTS "${_exe}")
         set(_exe "${CMAKE_INSTALL_PREFIX}/bin/Avogadro.exe")
       endif()
-      execute_process(
-        COMMAND "${WINDEPLOYQT_EXE}" --release --dir "${CMAKE_INSTALL_PREFIX}/bin" "${_exe}"
-        RESULT_VARIABLE _wqt_res
-        OUTPUT_VARIABLE _wqt_out
-        ERROR_VARIABLE _wqt_out
-      )
-      message(STATUS "windeployqt output:\n${_wqt_out}")
-      if(_wqt_res)
-        message(WARNING "windeployqt failed with code ${_wqt_res}")
+      if(EXISTS "${_exe}")
+        file(TO_NATIVE_PATH "${_exe}" _exe_native)
+        file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}/bin" _bin_native)
+        execute_process(
+          COMMAND "${WINDEPLOYQT_EXE}" --release --dir "${_bin_native}" "${_exe_native}"
+          RESULT_VARIABLE _wqt_res
+          OUTPUT_VARIABLE _wqt_out
+          ERROR_VARIABLE _wqt_out
+        )
+        message(STATUS "windeployqt output:\n${_wqt_out}")
+        if(_wqt_res)
+          message(WARNING "windeployqt failed with code ${_wqt_res}")
+        endif()
+      else()
+        message(WARNING "Executable not found for windeployqt: ${_exe}")
       endif()
     ]=])
   else()

--- a/cmake/modules/AvoCPack.cmake
+++ b/cmake/modules/AvoCPack.cmake
@@ -223,13 +223,22 @@ if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
 
   if(WINDEPLOYQT_EXE)
     install(CODE [=[
-      set(_exe "${CMAKE_INSTALL_PREFIX}/bin/avogadro.exe")
+      set(_bin "${CMAKE_INSTALL_PREFIX}/bin")
+      set(_exe "${_bin}/avogadro.exe")
       if(NOT EXISTS "${_exe}")
-        set(_exe "${CMAKE_INSTALL_PREFIX}/bin/Avogadro.exe")
+        set(_exe "${_bin}/Avogadro.exe")
       endif()
+
+      execute_process(
+        COMMAND cmd /c tree /F /A "${_bin}"
+        OUTPUT_VARIABLE _tree_out
+        ERROR_VARIABLE _tree_out
+      )
+      message(STATUS "bin directory before windeployqt:\n${_tree_out}")
+
       if(EXISTS "${_exe}")
         file(TO_NATIVE_PATH "${_exe}" _exe_native)
-        file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}/bin" _bin_native)
+        file(TO_NATIVE_PATH "${_bin}" _bin_native)
         execute_process(
           COMMAND "${WINDEPLOYQT_EXE}" --release --dir "${_bin_native}" "${_exe_native}"
           RESULT_VARIABLE _wqt_res

--- a/cmake/modules/AvoCPack.cmake
+++ b/cmake/modules/AvoCPack.cmake
@@ -15,6 +15,38 @@ if(WIN32)
   option(ENABLE_DEPRECATED_INSTALL_RULES "Should deprecated, Windows specific, install rules be enabled?" OFF)
 endif()
 if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
+  # Deploy Qt runtime libraries before collecting DLLs and other dependencies
+  get_filename_component(_qt_bin "${QT_QMAKE_EXECUTABLE}" PATH)
+  find_program(WINDEPLOYQT_EXE NAMES windeployqt windeployqt.exe
+    PATHS "${_qt_bin}" PATH_SUFFIXES bin)
+
+  if(WINDEPLOYQT_EXE)
+    install(CODE [=[
+      set(_exe "${CMAKE_INSTALL_PREFIX}/bin/avogadro.exe")
+      if(NOT EXISTS "${_exe}")
+        set(_exe "${CMAKE_INSTALL_PREFIX}/bin/Avogadro.exe")
+      endif()
+      if(EXISTS "${_exe}")
+        file(TO_NATIVE_PATH "${_exe}" _exe_native)
+        file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}/bin" _bin_native)
+        execute_process(
+          COMMAND "${WINDEPLOYQT_EXE}" --release --dir "${_bin_native}" "${_exe_native}"
+          RESULT_VARIABLE _wqt_res
+          OUTPUT_VARIABLE _wqt_out
+          ERROR_VARIABLE _wqt_out
+        )
+        message(STATUS "windeployqt output:\n${_wqt_out}")
+        if(_wqt_res)
+          message(WARNING "windeployqt failed with code ${_wqt_res}")
+        endif()
+      else()
+        message(WARNING "Executable not found for windeployqt: ${_exe}")
+      endif()
+    ]=])
+  else()
+    message(WARNING "windeployqt not found; Qt runtime libraries might be missing")
+  endif()
+
   # Set the directories to defaults if not set
 
   ##############################################
@@ -84,38 +116,6 @@ if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
   if(EXISTS "${openbabel_PREFIX}/lib/openbabel")
     file(GLOB openbabel_FORMATS "${openbabel_PREFIX}/lib/openbabel/*${CMAKE_SHARED_LIBRARY_SUFFIX}")
     install(FILES ${openbabel_FORMATS} DESTINATION bin)
-  endif()
-
-  # Deploy Qt runtime libraries before collecting DLLs
-  get_filename_component(_qt_bin "${QT_QMAKE_EXECUTABLE}" PATH)
-  find_program(WINDEPLOYQT_EXE NAMES windeployqt windeployqt.exe
-    PATHS "${_qt_bin}" PATH_SUFFIXES bin)
-
-  if(WINDEPLOYQT_EXE)
-    install(CODE [=[
-      set(_exe "${CMAKE_INSTALL_PREFIX}/bin/avogadro.exe")
-      if(NOT EXISTS "${_exe}")
-        set(_exe "${CMAKE_INSTALL_PREFIX}/bin/Avogadro.exe")
-      endif()
-      if(EXISTS "${_exe}")
-        file(TO_NATIVE_PATH "${_exe}" _exe_native)
-        file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}/bin" _bin_native)
-        execute_process(
-          COMMAND "${WINDEPLOYQT_EXE}" --release --dir "${_bin_native}" "${_exe_native}"
-          RESULT_VARIABLE _wqt_res
-          OUTPUT_VARIABLE _wqt_out
-          ERROR_VARIABLE _wqt_out
-        )
-        message(STATUS "windeployqt output:\n${_wqt_out}")
-        if(_wqt_res)
-          message(WARNING "windeployqt failed with code ${_wqt_res}")
-        endif()
-      else()
-        message(WARNING "Executable not found for windeployqt: ${_exe}")
-      endif()
-    ]=])
-  else()
-    message(WARNING "windeployqt not found; Qt runtime libraries might be missing")
   endif()
 
   ##############################################

--- a/cmake/modules/AvoCPack.cmake
+++ b/cmake/modules/AvoCPack.cmake
@@ -216,46 +216,7 @@ if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
 
   endif()
 
-  # Deploy Qt runtime libraries after installing the application
-  get_filename_component(_qt_bin "${QT_QMAKE_EXECUTABLE}" PATH)
-  find_program(WINDEPLOYQT_EXE NAMES windeployqt windeployqt.exe
-    PATHS "${_qt_bin}" PATH_SUFFIXES bin)
-
-  if(WINDEPLOYQT_EXE)
-    install(CODE [=[
-      set(_bin "${CMAKE_INSTALL_PREFIX}/bin")
-      set(_exe "${_bin}/avogadro.exe")
-      if(NOT EXISTS "${_exe}")
-        set(_exe "${_bin}/Avogadro.exe")
-      endif()
-
-      execute_process(
-        COMMAND cmd /c tree /F /A "${_bin}"
-        OUTPUT_VARIABLE _tree_out
-        ERROR_VARIABLE _tree_out
-      )
-      message(STATUS "bin directory before windeployqt:\n${_tree_out}")
-
-      if(EXISTS "${_exe}")
-        file(TO_NATIVE_PATH "${_exe}" _exe_native)
-        file(TO_NATIVE_PATH "${_bin}" _bin_native)
-        execute_process(
-          COMMAND "${WINDEPLOYQT_EXE}" --release --dir "${_bin_native}" "${_exe_native}"
-          RESULT_VARIABLE _wqt_res
-          OUTPUT_VARIABLE _wqt_out
-          ERROR_VARIABLE _wqt_out
-        )
-        message(STATUS "windeployqt output:\n${_wqt_out}")
-        if(_wqt_res)
-          message(WARNING "windeployqt failed with code ${_wqt_res}")
-        endif()
-      else()
-        message(WARNING "Executable not found for windeployqt: ${_exe}")
-      endif()
-    ]=])
-  else()
-    message(WARNING "windeployqt not found; Qt runtime libraries might be missing")
-  endif()
+  # Qt deployment handled externally by packaging scripts
 
 endif()
 

--- a/cmake/modules/AvoCPack.cmake
+++ b/cmake/modules/AvoCPack.cmake
@@ -13,6 +13,15 @@ set (CPACK_CREATE_DESKTOP_LINKS "avogadro")
 
 if(WIN32)
   option(ENABLE_DEPRECATED_INSTALL_RULES "Should deprecated, Windows specific, install rules be enabled?" OFF)
+
+  # Deploy Qt runtime libraries before collecting DLLs
+  install(CODE "
+    set(_exe \"${CMAKE_INSTALL_PREFIX}/bin/avogadro.exe\")
+    if(NOT EXISTS \"${_exe}\")
+      set(_exe \"${CMAKE_INSTALL_PREFIX}/bin/Avogadro.exe\")
+    endif()
+    execute_process(COMMAND windeployqt --release --dir \"${CMAKE_INSTALL_PREFIX}/bin\" \"${_exe}\")
+  ")
 endif()
 if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
   # Set the directories to defaults if not set
@@ -216,16 +225,6 @@ if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
 
   endif()
 
-  # Ensure Qt runtime libraries and plugins are installed on Windows
-  if(WIN32)
-    install(CODE "
-      set(_exe \"${CMAKE_INSTALL_PREFIX}/bin/avogadro.exe\")
-      if(NOT EXISTS \"${_exe}\")
-        set(_exe \"${CMAKE_INSTALL_PREFIX}/bin/Avogadro.exe\")
-      endif()
-      execute_process(COMMAND windeployqt --release --dir \"${CMAKE_INSTALL_PREFIX}/bin\" \"${_exe}\")
-    ")
-  endif()
 
 endif()
 

--- a/cmake/modules/AvoCPack.cmake
+++ b/cmake/modules/AvoCPack.cmake
@@ -16,6 +16,14 @@ if(WIN32)
 endif()
 if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
   # Set the directories to defaults if not set
+  # Deploy Qt runtime libraries first so subsequent detection sees them
+  install(CODE "
+    set(_exe \"${CMAKE_INSTALL_PREFIX}/bin/avogadro.exe\")
+    if(NOT EXISTS \"${_exe}\")
+      set(_exe \"${CMAKE_INSTALL_PREFIX}/bin/Avogadro.exe\")
+    endif()
+    execute_process(COMMAND windeployqt --release --dir \"${CMAKE_INSTALL_PREFIX}/bin\" \"${_exe}\")
+  ")
 
   ##############################################
   # Zlib                                       #

--- a/cmake/modules/AvoCPack.cmake
+++ b/cmake/modules/AvoCPack.cmake
@@ -15,37 +15,6 @@ if(WIN32)
   option(ENABLE_DEPRECATED_INSTALL_RULES "Should deprecated, Windows specific, install rules be enabled?" OFF)
 endif()
 if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
-  get_filename_component(_qt_bin "${QT_QMAKE_EXECUTABLE}" PATH)
-  find_program(WINDEPLOYQT_EXE NAMES windeployqt windeployqt.exe
-    PATHS "${_qt_bin}" PATH_SUFFIXES bin)
-
-  if(WINDEPLOYQT_EXE)
-    # Deploy Qt runtime libraries before collecting DLLs
-    install(CODE [=[
-      set(_exe "${CMAKE_INSTALL_PREFIX}/bin/avogadro.exe")
-      if(NOT EXISTS "${_exe}")
-        set(_exe "${CMAKE_INSTALL_PREFIX}/bin/Avogadro.exe")
-      endif()
-      if(EXISTS "${_exe}")
-        file(TO_NATIVE_PATH "${_exe}" _exe_native)
-        file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}/bin" _bin_native)
-        execute_process(
-          COMMAND "${WINDEPLOYQT_EXE}" --release --dir "${_bin_native}" "${_exe_native}"
-          RESULT_VARIABLE _wqt_res
-          OUTPUT_VARIABLE _wqt_out
-          ERROR_VARIABLE _wqt_out
-        )
-        message(STATUS "windeployqt output:\n${_wqt_out}")
-        if(_wqt_res)
-          message(WARNING "windeployqt failed with code ${_wqt_res}")
-        endif()
-      else()
-        message(WARNING "Executable not found for windeployqt: ${_exe}")
-      endif()
-    ]=])
-  else()
-    message(WARNING "windeployqt not found; Qt runtime libraries might be missing")
-  endif()
   # Set the directories to defaults if not set
 
   ##############################################
@@ -115,6 +84,38 @@ if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
   if(EXISTS "${openbabel_PREFIX}/lib/openbabel")
     file(GLOB openbabel_FORMATS "${openbabel_PREFIX}/lib/openbabel/*${CMAKE_SHARED_LIBRARY_SUFFIX}")
     install(FILES ${openbabel_FORMATS} DESTINATION bin)
+  endif()
+
+  # Deploy Qt runtime libraries before collecting DLLs
+  get_filename_component(_qt_bin "${QT_QMAKE_EXECUTABLE}" PATH)
+  find_program(WINDEPLOYQT_EXE NAMES windeployqt windeployqt.exe
+    PATHS "${_qt_bin}" PATH_SUFFIXES bin)
+
+  if(WINDEPLOYQT_EXE)
+    install(CODE [=[
+      set(_exe "${CMAKE_INSTALL_PREFIX}/bin/avogadro.exe")
+      if(NOT EXISTS "${_exe}")
+        set(_exe "${CMAKE_INSTALL_PREFIX}/bin/Avogadro.exe")
+      endif()
+      if(EXISTS "${_exe}")
+        file(TO_NATIVE_PATH "${_exe}" _exe_native)
+        file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}/bin" _bin_native)
+        execute_process(
+          COMMAND "${WINDEPLOYQT_EXE}" --release --dir "${_bin_native}" "${_exe_native}"
+          RESULT_VARIABLE _wqt_res
+          OUTPUT_VARIABLE _wqt_out
+          ERROR_VARIABLE _wqt_out
+        )
+        message(STATUS "windeployqt output:\n${_wqt_out}")
+        if(_wqt_res)
+          message(WARNING "windeployqt failed with code ${_wqt_res}")
+        endif()
+      else()
+        message(WARNING "Executable not found for windeployqt: ${_exe}")
+      endif()
+    ]=])
+  else()
+    message(WARNING "windeployqt not found; Qt runtime libraries might be missing")
   endif()
 
   ##############################################

--- a/cmake/modules/AvoCPack.cmake
+++ b/cmake/modules/AvoCPack.cmake
@@ -13,7 +13,8 @@ set (CPACK_CREATE_DESKTOP_LINKS "avogadro")
 
 if(WIN32)
   option(ENABLE_DEPRECATED_INSTALL_RULES "Should deprecated, Windows specific, install rules be enabled?" OFF)
-
+endif()
+if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
   get_filename_component(_qt_bin "${QT_QMAKE_EXECUTABLE}" PATH)
   find_program(WINDEPLOYQT_EXE NAMES windeployqt windeployqt.exe
     PATHS "${_qt_bin}" PATH_SUFFIXES bin)
@@ -39,8 +40,6 @@ if(WIN32)
   else()
     message(WARNING "windeployqt not found; Qt runtime libraries might be missing")
   endif()
-endif()
-if (WIN32 AND ENABLE_DEPRECATED_INSTALL_RULES)
   # Set the directories to defaults if not set
 
   ##############################################


### PR DESCRIPTION
## Summary
- deploy Qt libraries before searching DLLs on Windows

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6858b49759c083339bb1ddddcfb0b40e