### PR TITLE
Handle invalid OpenGL context on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ If hardware acceleration still fails, you can force Mesa's software renderer by
 setting `LIBGL_ALWAYS_SOFTWARE=1` before launching Avogadro, which avoids
 segmentation faults at the cost of slower rendering.
 
+If you run Valgrind under WSL, you may see invalid write warnings in
+`libnvwgf2umx.so` (the proprietary Nvidia driver). These originate from the
+driver itself and are not indicative of an Avogadro bug.
+
 Automated Windows installer builds are generated with GitHub Actions and can be
 found in the workflow artifacts. The workflow builds OpenBabel from
 <https://github.com/openbabel/openbabel> and bundles it with Avogadro.

--- a/libavogadro/src/glwidget.cpp
+++ b/libavogadro/src/glwidget.cpp
@@ -617,6 +617,8 @@ namespace Avogadro {
       if(!d->initialized) {
         d->initialized = true;
         initializeGL();
+        if(!context() || !context()->isValid())
+          return;
       }
       qglClearColor(d->background);
       paintGL();
@@ -637,6 +639,8 @@ namespace Avogadro {
     {
       d->initialized = true;
       initializeGL();
+      if(!context() || !context()->isValid())
+        return;
     }
     // GLXWaitX() is called by the TT resizeEvent on Linux... We may need
     // specific functions here - need to look at Mac and Windows code.


### PR DESCRIPTION
## Summary
- check that the GL context exists before accessing it
- expand README WSL troubleshooting section

## Testing
- `apt-get update`
- `apt-get install -y build-essential cmake qtbase5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libeigen3-dev libopenbabel-dev zlib1g-dev libglu1-mesa-dev`
- `cmake -DENABLE_TESTS=ON ..`
- `make -j2` *(failed: build interrupted)*
- `ctest -N`

------
https://chatgpt.com/codex/tasks/task_e_68590a25660c8333a3f4d01d29f795cd