### PR TITLE
Split Windows installer path for tests

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-installer:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [installer, tests]
     steps:
       - name: Allow Windows reserved filenames
         run: git config --system core.protectNTFS false
@@ -115,11 +118,13 @@ jobs:
           "$binDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Build OpenBabel
         shell: pwsh
+        env:
+          ENABLE_TESTS: ${{ matrix.target == 'tests' && 'ON' || 'OFF' }}
         run: |
           $srcDir = Join-Path $env:RUNNER_TEMP 'openbabel-src'
           git clone --depth 1 https://github.com/openbabel/openbabel $srcDir
           $build = Join-Path $srcDir 'build'
-          cmake -S $srcDir -B $build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$build\install" -DLIBXML2_LIBRARY="$env:LIBXML2_LIBRARY" -DLIBXML2_LIBRARIES="$env:LIBXML2_LIBRARY" -DLIBXML2_INCLUDE_DIR="$env:LIBXML2_INCLUDE_DIR" -DZLIB_LIBRARY="$env:ZLIB_LIBRARY" -DZLIB_INCLUDE_DIR="$env:ZLIB_INCLUDE_DIR" -DENABLE_TESTS=OFF -DBUILD_SHARED=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DOB_USE_PREBUILT_BINARIES=OFF -DOPENBABEL_USE_SYSTEM_INCHI=OFF -DWITH_INCHI=ON
+          cmake -S $srcDir -B $build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$build\install" -DLIBXML2_LIBRARY="$env:LIBXML2_LIBRARY" -DLIBXML2_LIBRARIES="$env:LIBXML2_LIBRARY" -DLIBXML2_INCLUDE_DIR="$env:LIBXML2_INCLUDE_DIR" -DZLIB_LIBRARY="$env:ZLIB_LIBRARY" -DZLIB_INCLUDE_DIR="$env:ZLIB_INCLUDE_DIR" "-DENABLE_TESTS=$env:ENABLE_TESTS" -DBUILD_SHARED=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DOB_USE_PREBUILT_BINARIES=OFF -DOPENBABEL_USE_SYSTEM_INCHI=OFF -DWITH_INCHI=ON
           Push-Location $build
           nmake install
           Pop-Location
@@ -137,6 +142,8 @@ jobs:
           "$obDir\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Configure
         shell: pwsh
+        env:
+          ENABLE_TESTS: ${{ matrix.target == 'tests' && 'ON' || 'OFF' }}
         run: |
           $dist = Join-Path $pwd 'scripts/installer/dist'
           cmake -S . -B build `
@@ -144,7 +151,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release `
             -DBUILD_SHARED_LIBS=ON `
             -DCMAKE_VERBOSE_MAKEFILE=ON `
-            -DENABLE_TESTS=OFF `
+            "-DENABLE_TESTS=$env:ENABLE_TESTS" `
             -DCMAKE_INSTALL_PREFIX="$dist" `
             -DENABLE_AVO_PACKAGE=ON `
             -DENABLE_GLSL=ON `
@@ -162,12 +169,15 @@ jobs:
         run: |
           cmake --build build --config Release --target install
       - name: Create installer
+        if: matrix.target == 'installer'
         shell: pwsh
         run: |
           python scripts/installer/create_installer.py
       - name: Test
+        if: matrix.target == 'tests'
         run: ctest --test-dir build -C Release --output-on-failure
       - name: Upload installer
+        if: matrix.target == 'installer'
         uses: actions/upload-artifact@v4
         with:
           name: avogadro-windows-installer


### PR DESCRIPTION
## Summary
- enable matrix for Windows workflow
- allow building installer or running tests after dependencies are installed

## Testing
- `git show --stat HEAD`

------
https://chatgpt.com/codex/tasks/task_e_685c3bdecc08833387938f5d72dd8c2e