### PR TITLE
Fix xtb optimizer stop

### DIFF
--- a/.github/apt-packages.txt
+++ b/.github/apt-packages.txt
@@ -9,3 +9,5 @@ libopenbabel-dev
 zlib1g-dev
 libglu1-mesa-dev
 libqt5test5t64
+xtb
+libxtb-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,24 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        xtb: [on]
     steps:
       - uses: actions/checkout@v3
       - name: Cache apt packages
         uses: actions/cache@v3
         with:
           path: /var/cache/apt/archives
-          key: ${{ runner.os }}-apt-${{ hashFiles('.github/apt-packages.txt') }}
+          key: ${{ runner.os }}-apt-${{ matrix.xtb }}-${{ hashFiles('.github/apt-packages.txt') }}
           restore-keys: ${{ runner.os }}-apt-
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo xargs -a .github/apt-packages.txt apt-get install -y
+          if [ "${{ matrix.xtb }}" = "on" ]; then
+            sudo apt-get install -y xtb libxtb-dev
+          fi
       - name: Configure
         run: |
           cmake -S . -B build \
@@ -26,4 +32,4 @@ jobs:
           cmake --build build -- -j1 VERBOSE=1
       - name: Test
         run: |
-          ctest --test-dir build   --output-on-failure
+          ctest --test-dir build --output-on-failure

--- a/libavogadro/src/tools/CMakeLists.txt
+++ b/libavogadro/src/tools/CMakeLists.txt
@@ -12,6 +12,10 @@ pkg_check_modules(XTB REQUIRED xtb)
 include_directories(${XTB_INCLUDE_DIRS})
 link_directories(${XTB_LIBRARY_DIRS})
 set(LINK_LIBS ${LINK_LIBS} ${XTB_LIBRARIES})
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+  set(LINK_LIBS ${LINK_LIBS} OpenMP::OpenMP_CXX)
+endif()
 set(PLUGIN_LABEL tools)
 set(PLUGIN_TARGET tools)
 add_custom_target(tools COMMENT "Meta target to build all Avogadro tools.")
@@ -53,6 +57,7 @@ endif()
 
 ### xtbopttool
 avogadro_plugin(xtbopttool xtbopttool.cpp xtbopttool.qrc)
+target_link_libraries(xtbopttool ${LINK_LIBS})
 
 ### navigatetool
 avogadro_plugin(navigatetool

--- a/libavogadro/src/tools/CMakeLists.txt
+++ b/libavogadro/src/tools/CMakeLists.txt
@@ -7,6 +7,11 @@ set(DESTINATION_DIR ${Avogadro_PLUGIN_INSTALL_DIR}/tools)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 set(LINK_LIBS avogadro)
+find_package(PkgConfig)
+pkg_check_modules(XTB REQUIRED xtb)
+include_directories(${XTB_INCLUDE_DIRS})
+link_directories(${XTB_LIBRARY_DIRS})
+set(LINK_LIBS ${LINK_LIBS} ${XTB_LIBRARIES})
 set(PLUGIN_LABEL tools)
 set(PLUGIN_TARGET tools)
 add_custom_target(tools COMMENT "Meta target to build all Avogadro tools.")
@@ -45,6 +50,9 @@ avogadro_plugin(autoopttool autoopttool.cpp autoopttool.qrc)
 if(${CMAKE_CXX_COMPILER_ID} MATCHES Intel AND UNIX)
   set_target_properties(autoopttool PROPERTIES COMPILE_FLAGS "-fvisibility=default")
 endif()
+
+### xtbopttool
+avogadro_plugin(xtbopttool xtbopttool.cpp xtbopttool.qrc)
 
 ### navigatetool
 avogadro_plugin(navigatetool

--- a/libavogadro/src/tools/xtbopttool.cpp
+++ b/libavogadro/src/tools/xtbopttool.cpp
@@ -1,0 +1,430 @@
+#include "xtbopttool.h"
+
+#include <avogadro/glwidget.h>
+#include <avogadro/camera.h>
+#include <avogadro/molecule.h>
+#include <avogadro/atom.h>
+#include <avogadro/painter.h>
+
+#include <QtWidgets/QAction>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QVBoxLayout>
+#include <Eigen/Core>
+#include <QtCore/QMutexLocker>
+
+#include <xtb.h>
+
+namespace Avogadro {
+
+XtbOptTool::XtbOptTool(QObject *parent)
+  : Tool(parent), m_glwidget(nullptr), m_thread(new XtbOptThread),
+    m_settingsWidget(nullptr), m_running(false),
+    m_setupFailed(false), m_threadsSpinBox(nullptr)
+{
+  QAction *action = activateAction();
+  action->setIcon(QIcon(QString::fromUtf8(":/xtbopttool/autoopttool.png")));
+  action->setToolTip(tr("xTB Optimization Tool"));
+
+  connect(m_thread, SIGNAL(finished(bool)), this, SLOT(finished(bool)));
+  connect(m_thread, SIGNAL(setupDone()), this, SLOT(setupDone()));
+  connect(m_thread, SIGNAL(setupFailed()), this, SLOT(setupFailed()));
+  connect(m_thread, SIGNAL(setupSucces()), this, SLOT(setupSucces()));
+  connect(m_thread, SIGNAL(finished()), this, SLOT(threadFinished()));
+}
+
+XtbOptTool::~XtbOptTool()
+{
+  if (m_thread) {
+    m_thread->stop();
+    m_thread->wait();
+    m_thread->cleanup();
+    delete m_thread;
+  }
+  if (m_settingsWidget)
+    m_settingsWidget->deleteLater();
+}
+
+int XtbOptTool::usefulness() const
+{
+  return 10;
+}
+
+QUndoCommand* XtbOptTool::mousePressEvent(GLWidget *widget, QMouseEvent *event)
+{
+  m_glwidget = widget;
+  m_lastDraggingPosition = event->pos();
+  m_clickedAtom = widget->computeClickedAtom(event->pos());
+  return nullptr;
+}
+
+QUndoCommand* XtbOptTool::mouseReleaseEvent(GLWidget *, QMouseEvent *)
+{
+  m_clickedAtom = nullptr;
+  return nullptr;
+}
+
+QUndoCommand* XtbOptTool::mouseMoveEvent(GLWidget *widget, QMouseEvent *event)
+{
+  if (m_running && m_clickedAtom) {
+    QPoint from = m_lastDraggingPosition;
+    QPoint to = event->pos();
+    translate(widget, *m_clickedAtom->pos(), from, to);
+    m_lastDraggingPosition = to;
+  }
+  return nullptr;
+}
+
+QUndoCommand* XtbOptTool::mouseDoubleClickEvent(GLWidget *, QMouseEvent *)
+{
+  return nullptr;
+}
+
+QUndoCommand* XtbOptTool::wheelEvent(GLWidget *, QWheelEvent *)
+{
+  return nullptr;
+}
+
+void XtbOptTool::translate(GLWidget *widget, const Eigen::Vector3d &what,
+                           const QPoint &from, const QPoint &to) const
+{
+  Eigen::Vector3d fromPos = widget->camera()->unProject(from, what);
+  Eigen::Vector3d toPos = widget->camera()->unProject(to, what);
+  Eigen::Vector3d atomTranslation = toPos - fromPos;
+  if (m_clickedAtom) {
+    QMutexLocker locker(&m_thread->mutex());
+    m_clickedAtom->setPos(atomTranslation + *m_clickedAtom->pos());
+    m_clickedAtom->update();
+  }
+}
+
+bool XtbOptTool::paint(GLWidget *widget)
+{
+  if (m_running || m_setupFailed) {
+    glColor3f(1.0, 1.0, 1.0);
+    if (m_setupFailed)
+      widget->painter()->drawText(QPoint(10, 20), tr("xTB setup failed"));
+    else
+      widget->painter()->drawText(QPoint(10, 20), tr("xTB optimizing..."));
+  }
+  return true;
+}
+
+QWidget* XtbOptTool::settingsWidget()
+{
+  if (!m_settingsWidget) {
+    m_settingsWidget = new QWidget;
+
+    QLabel *label = new QLabel(tr("Steps per Update:"));
+    m_stepsSpinBox = new QSpinBox(m_settingsWidget);
+    m_stepsSpinBox->setMinimum(1);
+    m_stepsSpinBox->setMaximum(50);
+    m_stepsSpinBox->setValue(4);
+
+    QLabel *threadsLabel = new QLabel(tr("Threads:"));
+    m_threadsSpinBox = new QSpinBox(m_settingsWidget);
+    m_threadsSpinBox->setMinimum(1);
+    m_threadsSpinBox->setMaximum(64);
+    m_threadsSpinBox->setValue(1);
+
+    m_buttonStartStop = new QPushButton(tr("Start"), m_settingsWidget);
+
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(label);
+    layout->addWidget(m_stepsSpinBox);
+    layout->addWidget(threadsLabel);
+    layout->addWidget(m_threadsSpinBox);
+    layout->addWidget(m_buttonStartStop);
+    layout->addStretch(1);
+    m_settingsWidget->setLayout(layout);
+
+    connect(m_buttonStartStop, SIGNAL(clicked()), this, SLOT(toggle()));
+    connect(m_settingsWidget, SIGNAL(destroyed()), this, SLOT(settingsWidgetDestroyed()));
+  }
+  return m_settingsWidget;
+}
+
+void XtbOptTool::settingsWidgetDestroyed()
+{
+  m_settingsWidget = nullptr;
+}
+
+void XtbOptTool::toggle()
+{
+  if (m_running)
+    disable();
+  else
+    enable();
+}
+
+void XtbOptTool::enable()
+{
+  if (m_running)
+    return;
+
+  if (!m_glwidget || !m_glwidget->molecule()) {
+    emit message(tr("No active molecule for xTB optimization"));
+    return;
+  }
+
+  connect(m_glwidget->molecule(), SIGNAL(destroyed()), this, SLOT(abort()));
+
+  QByteArray nt = QByteArray::number(m_threadsSpinBox ? m_threadsSpinBox->value() : 1);
+  qputenv("OMP_NUM_THREADS", nt);
+
+  if (!m_thread->setup(m_glwidget->molecule(), 0, m_stepsSpinBox->value())) {
+    m_setupFailed = true;
+    emit message(tr("Failed to initialize xTB"));
+    return;
+  }
+  m_setupFailed = false;
+  m_thread->start();
+  m_running = true;
+  m_buttonStartStop->setText(tr("Stop"));
+}
+
+void XtbOptTool::abort()
+{
+  disable();
+}
+
+void XtbOptTool::disable()
+{
+  if (!m_running)
+    return;
+
+  m_thread->stop();
+  if (m_buttonStartStop)
+    m_buttonStartStop->setEnabled(false);
+}
+
+void XtbOptTool::finished(bool)
+{
+  if (m_glwidget && m_glwidget->molecule()) {
+    QMutexLocker locker(&m_thread->mutex());
+    const std::vector<double> &coords = m_thread->coords();
+    int natoms = m_thread->natoms();
+    QList<Atom *> atoms = m_glwidget->molecule()->atoms();
+    if (atoms.size() >= natoms) {
+      const double bohr2ang = 0.52917721092;
+      for (int i = 0; i < natoms; ++i) {
+        double x = coords[3 * i] * bohr2ang;
+        double y = coords[3 * i + 1] * bohr2ang;
+        double z = coords[3 * i + 2] * bohr2ang;
+        atoms[i]->setPos(Eigen::Vector3d(x, y, z));
+      }
+    }
+    m_glwidget->molecule()->update();
+    m_glwidget->update();
+  }
+}
+
+void XtbOptTool::setupDone()
+{
+  // no timer needed when running in background thread
+}
+
+void XtbOptTool::setupFailed()
+{
+  m_setupFailed = true;
+  emit message(tr("xTB initialization failed"));
+  disable();
+  if (m_glwidget)
+    m_glwidget->update();
+}
+
+void XtbOptTool::setupSucces()
+{
+  m_setupFailed = false;
+}
+
+void XtbOptTool::threadFinished()
+{
+  m_thread->cleanup();
+  m_running = false;
+  m_setupFailed = false;
+  if (m_buttonStartStop)
+    m_buttonStartStop->setText(tr("Start"));
+  if (m_buttonStartStop)
+    m_buttonStartStop->setEnabled(true);
+  if (m_glwidget)
+    m_glwidget->update();
+}
+
+XtbOptThread::XtbOptThread(QObject *parent)
+  : QThread(parent), m_molecule(nullptr), m_env(nullptr), m_xtbMol(nullptr),
+    m_calc(nullptr), m_results(nullptr), m_stop(false)
+{
+}
+
+XtbOptThread::~XtbOptThread()
+{
+  if (m_results)
+    xtb_delResults(&m_results);
+  if (m_calc)
+    xtb_delCalculator(&m_calc);
+  if (m_xtbMol)
+    xtb_delMolecule(&m_xtbMol);
+  if (m_env)
+    xtb_delEnvironment(&m_env);
+}
+
+void XtbOptThread::cleanup()
+{
+  if (m_results) {
+    xtb_delResults(&m_results);
+    m_results = nullptr;
+  }
+  if (m_calc) {
+    xtb_delCalculator(&m_calc);
+    m_calc = nullptr;
+  }
+  if (m_xtbMol) {
+    xtb_delMolecule(&m_xtbMol);
+    m_xtbMol = nullptr;
+  }
+  if (m_env) {
+    xtb_delEnvironment(&m_env);
+    m_env = nullptr;
+  }
+}
+
+bool XtbOptThread::setup(Molecule *mol, int algorithm, int steps)
+{
+  Q_UNUSED(algorithm);
+  m_mutex.lock();
+  m_molecule = mol;
+  m_steps = steps;
+  m_stop = false;
+
+  m_env = xtb_newEnvironment();
+  if (!m_env) {
+    m_mutex.unlock();
+    emit setupFailed();
+    return false;
+  }
+  int natoms = m_molecule ? m_molecule->numAtoms() : 0;
+  m_numbers.resize(natoms);
+  m_coords.resize(natoms * 3);
+  const double ang2bohr = 1.8897259886;
+  for (int i=0;i<natoms;++i) {
+    const Atom *a = m_molecule->atom(i);
+    m_numbers[i] = a->atomicNumber();
+    Eigen::Vector3d p = *a->pos();
+    m_coords[3*i] = p.x()*ang2bohr;
+    m_coords[3*i+1] = p.y()*ang2bohr;
+    m_coords[3*i+2] = p.z()*ang2bohr;
+  }
+  double charge = 0.0;
+  int uhf = 0;
+  double lattice[3][3] = {{0,0,0},{0,0,0},{0,0,0}};
+  bool periodic[3] = {false,false,false};
+  m_xtbMol = xtb_newMolecule(m_env, &natoms, m_numbers.data(), m_coords.data(),
+                             &charge, &uhf, &lattice[0][0], periodic);
+  m_calc = xtb_newCalculator();
+  if (!m_xtbMol || !m_calc) {
+    m_mutex.unlock();
+    emit setupFailed();
+    return false;
+  }
+  xtb_loadGFN2xTB(m_env, m_xtbMol, m_calc, NULL);
+  m_results = xtb_newResults();
+  if (!m_results) {
+    m_mutex.unlock();
+    emit setupFailed();
+    return false;
+  }
+  m_mutex.unlock();
+  emit setupSucces();
+  emit setupDone();
+  return true;
+}
+
+void XtbOptThread::run()
+{
+  while (!m_stop) {
+    update();
+    if (m_stop)
+      break;
+    emit finished(true);
+  }
+}
+
+void XtbOptThread::update()
+{
+  QMutexLocker locker(&m_mutex);
+  if (!m_env || !m_xtbMol || !m_calc || !m_results || !m_molecule)
+    return;
+
+  int natoms = m_numbers.size();
+  const double ang2bohr = 1.8897259886;
+  for (int i = 0; i < natoms; ++i) {
+    const Atom *a = m_molecule->atom(i);
+    Eigen::Vector3d p = *a->pos();
+    m_coords[3 * i] = p.x() * ang2bohr;
+    m_coords[3 * i + 1] = p.y() * ang2bohr;
+    m_coords[3 * i + 2] = p.z() * ang2bohr;
+  }
+
+  for (int s = 0; s < m_steps && !m_stop; ++s) {
+    xtb_updateMolecule(m_env, m_xtbMol, m_coords.data(), NULL);
+    xtb_singlepoint(m_env, m_xtbMol, m_calc, m_results);
+    std::vector<double> grad(natoms * 3);
+    xtb_getGradient(m_env, m_results, grad.data());
+    double step = 0.1;
+    for (int i = 0; i < natoms * 3; ++i)
+      m_coords[i] -= step * grad[i];
+  }
+}
+
+void XtbOptThread::stop()
+{
+  m_stop = true;
+}
+
+XtbOptCommand::XtbOptCommand(Molecule *mol, XtbOptTool *tool, QUndoCommand *parent)
+  : QUndoCommand(parent), m_moleculeCopy(*mol), m_molecule(mol), m_tool(tool)
+{
+  setText(QObject::tr("xTB Optimize"));
+}
+
+void XtbOptCommand::redo()
+{
+  m_moleculeCopy = *m_molecule;
+}
+
+void XtbOptCommand::undo()
+{
+  if (m_tool)
+    m_tool->disable();
+  *m_molecule = m_moleculeCopy;
+}
+
+bool XtbOptCommand::mergeWith(const QUndoCommand *)
+{
+  return true;
+}
+
+int XtbOptCommand::id() const
+{
+  return 1311388;
+}
+
+void XtbOptTool::writeSettings(QSettings &settings) const
+{
+  Tool::writeSettings(settings);
+  if (m_stepsSpinBox)
+    settings.setValue("steps", m_stepsSpinBox->value());
+  if (m_threadsSpinBox)
+    settings.setValue("threads", m_threadsSpinBox->value());
+}
+
+void XtbOptTool::readSettings(QSettings &settings)
+{
+  Tool::readSettings(settings);
+  if (m_stepsSpinBox)
+    m_stepsSpinBox->setValue(settings.value("steps", 4).toInt());
+  if (m_threadsSpinBox)
+    m_threadsSpinBox->setValue(settings.value("threads", 1).toInt());
+}
+
+} // namespace Avogadro

--- a/libavogadro/src/tools/xtbopttool.cpp
+++ b/libavogadro/src/tools/xtbopttool.cpp
@@ -13,6 +13,9 @@
 #include <QtCore/QMutexLocker>
 
 #include <xtb.h>
+#ifdef _OPENMP
+#  include <omp.h>
+#endif
 
 namespace Avogadro {
 
@@ -175,6 +178,9 @@ void XtbOptTool::enable()
 
   QByteArray nt = QByteArray::number(m_threadsSpinBox ? m_threadsSpinBox->value() : 1);
   qputenv("OMP_NUM_THREADS", nt);
+#ifdef _OPENMP
+  omp_set_num_threads(m_threadsSpinBox ? m_threadsSpinBox->value() : 1);
+#endif
 
   if (!m_thread->setup(m_glwidget->molecule(), 0, m_stepsSpinBox->value())) {
     m_setupFailed = true;

--- a/libavogadro/src/tools/xtbopttool.cpp
+++ b/libavogadro/src/tools/xtbopttool.cpp
@@ -57,14 +57,16 @@ QUndoCommand* XtbOptTool::mousePressEvent(GLWidget *widget, QMouseEvent *event)
   return nullptr;
 }
 
-QUndoCommand* XtbOptTool::mouseReleaseEvent(GLWidget *, QMouseEvent *)
+QUndoCommand* XtbOptTool::mouseReleaseEvent(GLWidget *widget, QMouseEvent *)
 {
+  m_glwidget = widget;
   m_clickedAtom = nullptr;
   return nullptr;
 }
 
 QUndoCommand* XtbOptTool::mouseMoveEvent(GLWidget *widget, QMouseEvent *event)
 {
+  m_glwidget = widget;
   if (m_running && m_clickedAtom) {
     QPoint from = m_lastDraggingPosition;
     QPoint to = event->pos();
@@ -74,13 +76,15 @@ QUndoCommand* XtbOptTool::mouseMoveEvent(GLWidget *widget, QMouseEvent *event)
   return nullptr;
 }
 
-QUndoCommand* XtbOptTool::mouseDoubleClickEvent(GLWidget *, QMouseEvent *)
+QUndoCommand* XtbOptTool::mouseDoubleClickEvent(GLWidget *widget, QMouseEvent *)
 {
+  m_glwidget = widget;
   return nullptr;
 }
 
-QUndoCommand* XtbOptTool::wheelEvent(GLWidget *, QWheelEvent *)
+QUndoCommand* XtbOptTool::wheelEvent(GLWidget *widget, QWheelEvent *)
 {
+  m_glwidget = widget;
   return nullptr;
 }
 
@@ -99,6 +103,7 @@ void XtbOptTool::translate(GLWidget *widget, const Eigen::Vector3d &what,
 
 bool XtbOptTool::paint(GLWidget *widget)
 {
+  m_glwidget = widget;
   if (m_running || m_setupFailed) {
     glColor3f(1.0, 1.0, 1.0);
     if (m_setupFailed)

--- a/libavogadro/src/tools/xtbopttool.cpp
+++ b/libavogadro/src/tools/xtbopttool.cpp
@@ -351,18 +351,21 @@ void XtbOptThread::run()
 
 void XtbOptThread::update()
 {
-  QMutexLocker locker(&m_mutex);
-  if (!m_env || !m_xtbMol || !m_calc || !m_results || !m_molecule)
-    return;
+  int natoms;
+  {
+    QMutexLocker locker(&m_mutex);
+    if (!m_env || !m_xtbMol || !m_calc || !m_results || !m_molecule)
+      return;
 
-  int natoms = m_numbers.size();
-  const double ang2bohr = 1.8897259886;
-  for (int i = 0; i < natoms; ++i) {
-    const Atom *a = m_molecule->atom(i);
-    Eigen::Vector3d p = *a->pos();
-    m_coords[3 * i] = p.x() * ang2bohr;
-    m_coords[3 * i + 1] = p.y() * ang2bohr;
-    m_coords[3 * i + 2] = p.z() * ang2bohr;
+    natoms = m_numbers.size();
+    const double ang2bohr = 1.8897259886;
+    for (int i = 0; i < natoms; ++i) {
+      const Atom *a = m_molecule->atom(i);
+      Eigen::Vector3d p = *a->pos();
+      m_coords[3 * i] = p.x() * ang2bohr;
+      m_coords[3 * i + 1] = p.y() * ang2bohr;
+      m_coords[3 * i + 2] = p.z() * ang2bohr;
+    }
   }
 
   for (int s = 0; s < m_steps && !m_stop; ++s) {

--- a/libavogadro/src/tools/xtbopttool.h
+++ b/libavogadro/src/tools/xtbopttool.h
@@ -39,6 +39,7 @@
 #include <QtWidgets/QPushButton>
 #include <QtWidgets/QSpinBox>
 #include <QtWidgets/QUndoStack>
+#include <QtWidgets/QProgressBar>
 
 namespace Avogadro {
 
@@ -64,6 +65,7 @@ namespace Avogadro {
       void setupDone();
       void setupFailed();
       void setupSucces();
+      void progress(int step, int total, double energy);
 
     public Q_SLOTS:
       void stop();
@@ -142,6 +144,7 @@ namespace Avogadro {
       void disable();
       void abort();
       void threadFinished();
+      void updateProgress(int step, int total, double energy);
 
     protected:
       GLWidget *                m_glwidget;
@@ -154,9 +157,11 @@ namespace Avogadro {
       QSpinBox*                 m_stepsSpinBox;
       QPushButton*              m_buttonStartStop;
       QSpinBox*                 m_threadsSpinBox;
+      QProgressBar*             m_progressBar;
 
       QPoint                    m_lastDraggingPosition;
       double                    m_lastEnergy;
+      double                    m_deltaEnergy;
 
 
       void translate(GLWidget *widget, const Eigen::Vector3d &what, const QPoint &from, const QPoint &to) const;

--- a/libavogadro/src/tools/xtbopttool.h
+++ b/libavogadro/src/tools/xtbopttool.h
@@ -1,0 +1,195 @@
+/**********************************************************************
+  XtbOptTool - Automatic Optimization Tool for Avogadro
+
+  Copyright (C) 2007,2008 by Marcus D. Hanwell
+  Copyright (C) 2007 by Geoffrey R. Hutchison
+  Copyright (C) 2007 by Benoit Jacob
+  Copyright (C) 2008 by Tim Vandermeersch
+
+  This file is part of the Avogadro molecular editor project.
+  For more information, see <http://avogadro.cc/>
+
+  Some code is based on Open Babel
+  For more information, see <http://openbabel.sourceforge.net/>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation version 2 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ ***********************************************************************/
+
+#ifndef XTBOPTTOOL_H
+#define XTBOPTTOOL_H
+
+#include <avogadro/glwidget.h>
+#include <avogadro/tool.h>
+#include <avogadro/molecule.h>
+
+#include <xtb.h>
+#include <Eigen/Core>
+
+#include <QtCore/QMutex>
+#include <QtCore/QThread>
+#include <QtCore/QSettings>
+#include <QtWidgets/QAction>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QSpinBox>
+#include <QtWidgets/QUndoStack>
+
+namespace Avogadro {
+
+  class XtbOptThread : public QThread
+  {
+    Q_OBJECT
+
+    public:
+      XtbOptThread(QObject *parent=0);
+      ~XtbOptThread();
+
+      bool setup(Molecule *molecule, int algorithm, int steps);
+
+      void run();
+      void update();
+      const std::vector<double>& coords() const { return m_coords; }
+      int natoms() const { return static_cast<int>(m_numbers.size()); }
+      QMutex& mutex() { return m_mutex; }
+      void cleanup();
+
+    Q_SIGNALS:
+      void finished(bool calculated);
+      void setupDone();
+      void setupFailed();
+      void setupSucces();
+
+    public Q_SLOTS:
+      void stop();
+
+    private:
+      Molecule *m_molecule;
+      xtb_TEnvironment m_env;
+      xtb_TMolecule m_xtbMol;
+      xtb_TCalculator m_calc;
+      xtb_TResults m_results;
+      std::vector<int> m_numbers;
+      std::vector<double> m_coords;
+      bool m_velocities;
+      int m_algorithm;
+      //double m_convergence;
+      int m_steps;
+      bool m_stop;
+      QMutex m_mutex;
+  };
+
+  /**
+   * @class XtbOptTool
+   * @brief Automatic Optimization Tool
+   * @author Marcus D. Hanwell
+   *
+   * This tool enables the manipulation of the position of
+   * the selected atoms while the optimiser is running.
+   */
+  class XtbOptTool : public Tool
+  {
+    Q_OBJECT
+      AVOGADRO_TOOL("XtbOptimization", tr("XtbOptimization"),
+                    tr("Automatic optimization of molecular geometry"),
+                    tr("XtbOptimization Settings"))
+
+    public:
+      //! Constructor
+      XtbOptTool(QObject *parent = 0);
+      //! Deconstructor
+      virtual ~XtbOptTool();
+
+      //! \name Tool Methods
+      //@{
+      //! \brief Callback methods for ui.actions on the canvas.
+      /*!
+      */
+      virtual QUndoCommand* mousePressEvent(GLWidget *widget, QMouseEvent *event);
+      virtual QUndoCommand* mouseReleaseEvent(GLWidget *widget, QMouseEvent *event);
+      virtual QUndoCommand* mouseMoveEvent(GLWidget *widget, QMouseEvent *event);
+      virtual QUndoCommand* mouseDoubleClickEvent(GLWidget *widget, QMouseEvent *event);
+      virtual QUndoCommand* wheelEvent(GLWidget *widget, QWheelEvent *event);
+
+      virtual int usefulness() const;
+
+      virtual bool paint(GLWidget *widget);
+
+      virtual QWidget* settingsWidget();
+      /**
+       * Write the tool settings so that they can be saved between sessions.
+       */
+      virtual void writeSettings(QSettings &settings) const;
+
+      /**
+       * Read in the settings that have been saved for the tool instance.
+       */
+      virtual void readSettings(QSettings &settings);
+
+
+    public Q_SLOTS:
+      void finished(bool calculated);
+      void setupDone();
+      void setupFailed();
+      void setupSucces();
+      void toggle();
+      void enable();
+      void disable();
+      void abort();
+      void threadFinished();
+
+    protected:
+      GLWidget *                m_glwidget;
+      Atom *                    m_clickedAtom;
+      bool                      m_running;
+      bool                      m_setupFailed;
+      QWidget*                  m_settingsWidget;
+      XtbOptThread *            m_thread;
+
+      QSpinBox*                 m_stepsSpinBox;
+      QPushButton*              m_buttonStartStop;
+      QSpinBox*                 m_threadsSpinBox;
+
+      QPoint                    m_lastDraggingPosition;
+      double                    m_lastEnergy;
+
+
+      void translate(GLWidget *widget, const Eigen::Vector3d &what, const QPoint &from, const QPoint &to) const;
+
+    private Q_SLOTS:
+      void settingsWidgetDestroyed();
+  };
+
+  class XtbOptCommand : public QUndoCommand
+  {
+    public:
+      XtbOptCommand(Molecule *molecule, XtbOptTool *tool, QUndoCommand *parent = 0);
+
+      void redo();
+      void undo();
+      bool mergeWith ( const QUndoCommand * command );
+      int id() const;
+
+    private:
+      Molecule m_moleculeCopy;
+      Molecule *m_molecule;
+      XtbOptTool *m_tool;
+      bool undone;
+  };
+
+  class XtbOptToolFactory : public QObject, public PluginFactory
+  {
+    Q_OBJECT
+    Q_INTERFACES(Avogadro::PluginFactory)
+    Q_PLUGIN_METADATA(IID "net.sourceforge.avogadro.pluginfactory/1.5")
+    AVOGADRO_TOOL_FACTORY(XtbOptTool)
+  };
+
+} // end namespace Avogadro
+
+#endif

--- a/libavogadro/src/tools/xtbopttool.qrc
+++ b/libavogadro/src/tools/xtbopttool.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/xtbopttool">
+        <file>autoopttool.png</file>
+    </qresource>
+</RCC>

--- a/libavogadro/tests/CMakeLists.txt
+++ b/libavogadro/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(tests
   moleculefile
   neighborlist
   addremovehydrogens
+  xtbopttool
 )
 
 foreach (test ${tests})
@@ -56,6 +57,13 @@ foreach (test ${tests})
   set_property(TARGET ${test}test PROPERTY LABELS avogadro)
   set_property(TEST ${test}Test PROPERTY LABELS avogadro)
 endforeach ()
+
+find_package(PkgConfig)
+pkg_check_modules(XTB REQUIRED xtb)
+include_directories(${XTB_INCLUDE_DIRS})
+link_directories(${XTB_LIBRARY_DIRS})
+target_link_libraries(xtbopttooltest ${XTB_LIBRARIES})
+
 
 # More complicated tests (i.e., with linking)
 #message(STATUS "Test:  primitivemodeltest")

--- a/libavogadro/tests/CMakeLists.txt
+++ b/libavogadro/tests/CMakeLists.txt
@@ -64,6 +64,11 @@ include_directories(${XTB_INCLUDE_DIRS})
 link_directories(${XTB_LIBRARY_DIRS})
 target_link_libraries(xtbopttooltest ${XTB_LIBRARIES})
 
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+  target_link_libraries(xtbopttooltest OpenMP::OpenMP_CXX)
+endif()
+
 
 # More complicated tests (i.e., with linking)
 #message(STATUS "Test:  primitivemodeltest")

--- a/libavogadro/tests/xtbopttooltest.cpp
+++ b/libavogadro/tests/xtbopttooltest.cpp
@@ -1,0 +1,106 @@
+#include "config.h"
+#include <QtTest>
+
+#include <avogadro/pluginmanager.h>
+#include <avogadro/tool.h>
+#include <avogadro/molecule.h>
+#include <avogadro/atom.h>
+#include <xtb.h>
+#include <QDir>
+
+using Avogadro::PluginManager;
+using Avogadro::Tool;
+
+class XtbOptToolTest : public QObject
+{
+  Q_OBJECT
+private slots:
+  void pluginLoaded();
+  void optimizeWater();
+};
+
+void XtbOptToolTest::pluginLoaded()
+{
+  QStringList pluginDirs = PluginManager::instance()->pluginPath();
+  bool pluginExists = false;
+  foreach (const QString &dir, pluginDirs) {
+    QDir d(dir);
+    QStringList files = d.entryList(QStringList() << "*xtbopttool*", QDir::Files);
+    if (!files.isEmpty()) {
+      pluginExists = true;
+      break;
+    }
+  }
+  if (!pluginExists)
+    QSKIP("xtbopttool plugin not built");
+
+  QList<Tool *> tools = PluginManager::instance()->tools(this);
+  bool found = false;
+  foreach (Tool *tool, tools) {
+    if (tool->objectName() == QLatin1String("XtbOptimization")) {
+      found = true;
+      break;
+    }
+  }
+  QVERIFY(found);
+}
+
+void XtbOptToolTest::optimizeWater()
+{
+  Avogadro::Molecule mol;
+  Avogadro::Atom *o = mol.addAtom(8, Eigen::Vector3d(0.0, 0.0, 0.0));
+  Avogadro::Atom *h1 = mol.addAtom(1, Eigen::Vector3d(2.0, 0.0, 0.0));
+  Avogadro::Atom *h2 = mol.addAtom(1, Eigen::Vector3d(-2.0, 0.0, 0.0));
+  mol.addBond(o, h1);
+  mol.addBond(o, h2);
+
+  double initialDist = (*h1->pos() - *o->pos()).norm();
+
+  xtb_TEnvironment env = xtb_newEnvironment();
+  int natoms = mol.numAtoms();
+  std::vector<int> nums(natoms);
+  std::vector<double> coords(natoms * 3);
+  const double ang2bohr = 1.8897259886;
+  for (int i = 0; i < natoms; ++i) {
+    Avogadro::Atom *a = mol.atom(i);
+    nums[i] = a->atomicNumber();
+    Eigen::Vector3d p = *a->pos();
+    coords[3 * i] = p.x() * ang2bohr;
+    coords[3 * i + 1] = p.y() * ang2bohr;
+    coords[3 * i + 2] = p.z() * ang2bohr;
+  }
+  double charge = 0.0;
+  int uhf = 0;
+  double lattice[3][3] = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
+  bool periodic[3] = {false, false, false};
+  xtb_TMolecule xmol = xtb_newMolecule(env, &natoms, nums.data(), coords.data(),
+                                       &charge, &uhf, &lattice[0][0], periodic);
+  xtb_TCalculator calc = xtb_newCalculator();
+  xtb_loadGFN2xTB(env, xmol, calc, NULL);
+  xtb_TResults res = xtb_newResults();
+
+  for (int s = 0; s < 50; ++s) {
+    xtb_updateMolecule(env, xmol, coords.data(), NULL);
+    xtb_singlepoint(env, xmol, calc, res);
+    std::vector<double> grad(natoms * 3);
+    xtb_getGradient(env, res, grad.data());
+    double step = 0.1;
+    for (int i = 0; i < natoms * 3; ++i)
+      coords[i] -= step * grad[i];
+  }
+
+  xtb_delResults(&res);
+  xtb_delCalculator(&calc);
+  xtb_delMolecule(&xmol);
+  xtb_delEnvironment(&env);
+
+  const double bohr2ang = 0.52917721092;
+  double optimizedDist =
+      std::sqrt(std::pow(coords[3] * bohr2ang - coords[0] * bohr2ang, 2) +
+                std::pow(coords[4] * bohr2ang - coords[1] * bohr2ang, 2) +
+                std::pow(coords[5] * bohr2ang - coords[2] * bohr2ang, 2));
+  QVERIFY(optimizedDist < initialDist);
+}
+
+QTEST_MAIN(XtbOptToolTest)
+#include "moc_xtbopttooltest.cpp"


### PR DESCRIPTION
## Summary
- handle xTB thread completion asynchronously
- clean up xTB objects when the thread ends
- disable the stop button until the thread finishes

## Testing
- `cmake -DENABLE_TESTS=ON ..`
- `make xtbopttooltest -j4`
- `ctest -R xtbopttoolTest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_685cd3f88cc4833380e3dd215d7c5417