### PR TITLE
Handle invalid OpenGL context on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ GNU General Public License for more details.
 
 See INSTALL file for installation instructions.
 
+## Running under WSL
+
+Avogadro relies on an OpenGL-capable system. When running inside Windows
+Subsystem for Linux (WSL), ensure WSL2 with WSLg or another GPU provider is
+available. If you see errors such as `ZINK: failed to choose pdev` or
+`glx: failed to create drisw screen` followed by a segmentation fault,
+your environment does not provide a valid OpenGL context.
+Run `glxinfo -B` to confirm that WSL exposes your GPU. If the vendor shows
+"Microsoft" or the context fails, install the necessary GPU drivers or run the
+native Windows version of Avogadro instead. Setting `MESA_D3D12_DEFAULT_ADAPTER_NAME`
+to your GPU name can also help WSL pick the correct adapter.
+If hardware acceleration still fails, you can force Mesa's software renderer by
+setting `LIBGL_ALWAYS_SOFTWARE=1` before launching Avogadro, which avoids
+segmentation faults at the cost of slower rendering.
+
+If you run Valgrind under WSL, you may see invalid write warnings in
+`libnvwgf2umx.so` (the proprietary Nvidia driver). These originate from the
+driver itself and are not indicative of an Avogadro bug. Mesa's software
+renderer can show similar warnings inside `libgallium` as it manages GPU
+buffers.
+
 Automated Windows installer builds are generated with GitHub Actions and can be
 found in the workflow artifacts. The workflow builds OpenBabel from
 <https://github.com/openbabel/openbabel> and bundles it with Avogadro.

--- a/libavogadro/src/glwidget.cpp
+++ b/libavogadro/src/glwidget.cpp
@@ -35,6 +35,7 @@
 #include "glhit.h"
 
 #include <QtWidgets/QMessageBox>
+#include <QtWidgets/QApplication>
 #include <QtGui/QPen>
 #include <QtGui/QPainter>
 #include <QtGui/QPaintEngine>
@@ -478,7 +479,7 @@ namespace Avogadro {
   void GLWidget::initializeGL()
   {
     qDebug() << "GLWidget initialisation...";
-    if(!context()->isValid())
+    if(!context() || !context()->isValid())
     {
       // this should never happen, as we checked for availability of features that we requested in
       // the default OpenGL format. However it happened to a user who had a very broken setting with
@@ -489,7 +490,8 @@ namespace Avogadro {
                                    "or you found a bug.");
       qDebug() << error_msg;
       QMessageBox::critical(0, tr("OpenGL error"), error_msg);
-      abort();
+      qApp->exit(-1);
+      return;
     }
 
     // Try to initialise GLEW if GLSL was enabled, test for OpenGL 2.0 support
@@ -615,6 +617,8 @@ namespace Avogadro {
       if(!d->initialized) {
         d->initialized = true;
         initializeGL();
+        if(!context() || !context()->isValid())
+          return;
       }
       qglClearColor(d->background);
       paintGL();
@@ -635,6 +639,8 @@ namespace Avogadro {
     {
       d->initialized = true;
       initializeGL();
+      if(!context() || !context()->isValid())
+        return;
     }
     // GLXWaitX() is called by the TT resizeEvent on Linux... We may need
     // specific functions here - need to look at Mac and Windows code.

--- a/libavogadro/src/sphere_p.cpp
+++ b/libavogadro/src/sphere_p.cpp
@@ -203,7 +203,9 @@ namespace Avogadro {
     glEndList();
     glDisableClientState( GL_VERTEX_ARRAY );
     glDisableClientState( GL_NORMAL_ARRAY );
-    freeBuffers();
+    // Do not free the buffers here. The display list stores pointers to the
+    // vertex and index arrays, so they must remain valid until the sphere is
+    // destroyed.
     d->isValid = true;
   }
 


### PR DESCRIPTION
## Summary
- check that the GL context exists before accessing it
- expand README WSL troubleshooting section with valgrind note
- document how to use LIBGL_ALWAYS_SOFTWARE for software rendering
- keep sphere buffers in memory to avoid invalid writes when executing display lists

## Testing
- `cmake -DENABLE_TESTS=ON ..`
- `make -j2` *(failed: build interrupted)*
- `ctest -N`

------
https://chatgpt.com/codex/tasks/task_e_68590a25660c8333a3f4d01d29f795cd