### PR TITLE
Add Fit View extension

### DIFF
--- a/libavogadro/src/extensions/CMakeLists.txt
+++ b/libavogadro/src/extensions/CMakeLists.txt
@@ -122,6 +122,9 @@ avogadro_plugin_nogl(supercellextension
 avogadro_plugin_nogl(networkfetchextension networkfetchextension.cpp)
 target_link_libraries(networkfetchextension ${QT_QTNETWORK_LIBRARY})
 
+# Fit view / zoom to molecule
+avogadro_plugin_nogl(fitviewextension fitviewextension.cpp)
+
 # GL2PS
 avogadro_plugin(gl2psextension
   "gl2psextension.cpp;gl2ps/gl2ps.c")

--- a/libavogadro/src/extensions/fitviewextension.cpp
+++ b/libavogadro/src/extensions/fitviewextension.cpp
@@ -1,0 +1,41 @@
+#include "fitviewextension.h"
+#include <avogadro/glwidget.h>
+#include <avogadro/camera.h>
+
+#include <QAction>
+
+namespace Avogadro {
+
+FitViewExtension::FitViewExtension(QObject *parent)
+  : Extension(parent)
+{
+  QAction *action = new QAction(this);
+  action->setText(tr("Fit to Screen"));
+  m_actions.append(action);
+}
+
+FitViewExtension::~FitViewExtension()
+{
+}
+
+QList<QAction *> FitViewExtension::actions() const
+{
+  return m_actions;
+}
+
+QString FitViewExtension::menuPath(QAction *) const
+{
+  return tr("&View");
+}
+
+QUndoCommand *FitViewExtension::performAction(QAction *, GLWidget *widget)
+{
+  if (!widget)
+    return 0;
+
+  widget->camera()->initializeViewPoint();
+  widget->update();
+  return 0;
+}
+
+} // namespace Avogadro

--- a/libavogadro/src/extensions/fitviewextension.h
+++ b/libavogadro/src/extensions/fitviewextension.h
@@ -1,0 +1,38 @@
+#ifndef FITVIEWEXTENSION_H
+#define FITVIEWEXTENSION_H
+
+#include <avogadro/extension.h>
+#include <QAction>
+#include <QList>
+
+namespace Avogadro {
+
+class FitViewExtension : public Extension
+{
+  Q_OBJECT
+  AVOGADRO_EXTENSION("FitView", tr("Fit View"),
+                     tr("Center and zoom to fit the molecule"))
+
+public:
+  explicit FitViewExtension(QObject *parent = 0);
+  ~FitViewExtension();
+
+  QList<QAction *> actions() const;
+  QUndoCommand *performAction(QAction *action, GLWidget *widget);
+  QString menuPath(QAction *action) const;
+
+private:
+  QList<QAction *> m_actions;
+};
+
+class FitViewExtensionFactory : public QObject, public PluginFactory
+{
+  Q_OBJECT
+  Q_INTERFACES(Avogadro::PluginFactory)
+  Q_PLUGIN_METADATA(IID "net.sourceforge.avogadro.pluginfactory/1.5")
+  AVOGADRO_EXTENSION_FACTORY(FitViewExtension)
+};
+
+} // namespace Avogadro
+
+#endif // FITVIEWEXTENSION_H


### PR DESCRIPTION
## Summary
- add new `FitView` extension plugin that centers and zooms to fit the molecule
- register plugin in extensions CMake build

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON` *(failed: build aborted)*
- `ctest` *(failed: missing compiled test executables)*

------
https://chatgpt.com/codex/tasks/task_e_685e56d0d2bc8333b782e725f50c7583