### PR TITLE
Add xTB Windows installer

### DIFF
--- a/.github/workflows/windows-xtb-installer.yml
+++ b/.github/workflows/windows-xtb-installer.yml
@@ -1,0 +1,248 @@
+name: Windows Installer
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master, windows-install ]
+  pull_request:
+
+jobs:
+  build-installer:
+    runs-on: windows-latest
+    env:
+      WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/09a8acaf-265f-4460-866c-a3375ed5b4ff/intel-oneapi-base-toolkit-2025.2.0.591_offline.exe
+      WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3bbdaf75-6728-492e-a18c-be654dae9ee2/intel-oneapi-hpc-toolkit-2025.2.0.576_offline.exe
+    strategy:
+      matrix:
+        target: [installer, tests]
+    steps:
+      - name: Allow Windows reserved filenames
+        run: git config --system core.protectNTFS false
+      - uses: actions/checkout@v4
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Install dependencies
+        run: choco install -y cmake --version=3.28.6 `
+          --no-progress `
+          --installargs '"ADD_CMAKE_TO_PATH=System"' `
+          --allow-downgrade   # harmless if no newer CMake is present
+      - name: Install Intel oneAPI
+        shell: pwsh
+        run: |
+          $tmp = $env:RUNNER_TEMP
+          $baseExe = Join-Path $tmp 'oneapi_base.exe'
+          $hpcExe = Join-Path $tmp 'oneapi_hpc.exe'
+          Invoke-WebRequest $env:WINDOWS_BASEKIT_URL -OutFile $baseExe
+          Invoke-WebRequest $env:WINDOWS_HPCKIT_URL -OutFile $hpcExe
+          Start-Process $baseExe -Wait -ArgumentList '-s','-x','-f',"$tmp\base_extracted","--log","extract.log"
+          Start-Process $hpcExe -Wait -ArgumentList '-s','-x','-f',"$tmp\hpc_extracted","--log","extract.log"
+          Remove-Item $baseExe, $hpcExe -ErrorAction SilentlyContinue
+          & "$tmp\base_extracted\bootstrapper.exe" -s --action install --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=.
+          & "$tmp\hpc_extracted\bootstrapper.exe" -s --action install --components=intel.oneapi.win.ifort-compiler --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=.
+          Remove-Item -Recurse -Force "$tmp\base_extracted","$tmp\hpc_extracted" -ErrorAction SilentlyContinue
+          $runtime = 'C:\Program Files (x86)\Intel\oneAPI\compiler\latest\windows\redist\intel64_win'
+          "FORTRAN_RUNTIME_DIR=$runtime" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Build zlib
+        shell: pwsh
+        run: |
+          $ver = '1.3.1'
+          $zip = "$env:RUNNER_TEMP\zlib.zip"
+          Invoke-WebRequest "https://zlib.net/zlib$($ver -replace '\.', '').zip" -OutFile $zip
+          Expand-Archive $zip -DestinationPath $env:RUNNER_TEMP
+          $src = Join-Path $env:RUNNER_TEMP "zlib-$ver"
+          $bld = Join-Path $src "build"
+          cmake -S "$src" -B "$bld" -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$bld\install" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release
+          Push-Location $bld
+          nmake install
+          Pop-Location
+          $zlibDir = Join-Path $bld "install"
+          $inc = Join-Path $zlibDir "include"
+          $libDir = Join-Path $zlibDir "lib"
+          $static = Join-Path $libDir "zlibstatic.lib"
+          $lib = Join-Path $libDir "zlib.lib"
+          Copy-Item $static $lib -Force
+          "CMAKE_PREFIX_PATH=$zlibDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_INCLUDE_PATH=$inc;$env:CMAKE_INCLUDE_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_LIBRARY_PATH=$libDir;$env:CMAKE_LIBRARY_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "ZLIB_LIBRARY=$lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "ZLIB_INCLUDE_DIR=$inc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "ZLIB_LIBRARY_DIR=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "$zlibDir\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Install Eigen
+        shell: pwsh
+        run: |
+          $ver = '3.4.0'
+          $zip = "$env:RUNNER_TEMP\eigen.zip"
+          Invoke-WebRequest "https://gitlab.com/libeigen/eigen/-/archive/$ver/eigen-$ver.zip" -OutFile $zip
+          Expand-Archive $zip -DestinationPath $env:RUNNER_TEMP
+          $dir = Join-Path $env:RUNNER_TEMP "eigen-$ver"
+          "EIGEN3_INCLUDE_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_PREFIX_PATH=$dir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Build libxml2
+        shell: pwsh
+        run: |
+          $ver = '2.12.10'
+          $zip = "$env:RUNNER_TEMP\libxml2.zip"
+          Invoke-WebRequest "https://github.com/GNOME/libxml2/archive/refs/tags/v$ver.zip" -OutFile $zip
+          Expand-Archive $zip -DestinationPath $env:RUNNER_TEMP
+          $src = Join-Path $env:RUNNER_TEMP "libxml2-$ver"
+          $installDir = Join-Path $src 'install'
+          $win32 = Join-Path $src 'win32'
+          Push-Location $win32
+          cscript configure.js compiler=msvc prefix=$installDir iconv=no zlib=yes include=$env:ZLIB_INCLUDE_DIR lib=$env:ZLIB_LIBRARY_DIR
+          (Get-Content Makefile.msvc).Replace('/OPT:NOWIN98','').Replace('zdll.lib','zlib.lib') | Set-Content Makefile.msvc
+          $conf = Join-Path $src 'config.h'
+          if (Test-Path $conf) {
+            (Get-Content $conf) -replace '^#define snprintf.*', '// removed snprintf define' -replace '^#define vsnprintf.*', '// removed vsnprintf define' | Set-Content $conf
+          }
+          nmake /f Makefile.msvc
+          nmake /f Makefile.msvc install
+          Pop-Location
+          Write-Host "libxml2 library path after install:" $installDir
+          $inc = Join-Path $installDir 'include'
+          $lib = Join-Path $installDir 'lib' 'libxml2.lib'
+          "CMAKE_PREFIX_PATH=$installDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "LIBXML2_LIBRARY=$lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "LIBXML2_LIBRARIES=$lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "LIBXML2_INCLUDE_DIR=$inc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Install Qt
+        shell: pwsh
+        run: |
+          python -m pip install aqtinstall
+          $qtDir = "C:\\Qt"
+          python -m aqt install-qt windows desktop 5.15.2 win64_msvc2019_64 -O $qtDir -m qtcharts qtscript
+          $qt = "$qtDir\5.15.2\msvc2019_64"
+          "Qt5_DIR=$qt" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_PREFIX_PATH=$qt;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "$qt\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Build GLEW
+        shell: pwsh
+        run: |
+          $ver = '2.2.0'
+          $zip = "$env:RUNNER_TEMP\glew.zip"
+          Invoke-WebRequest "https://github.com/nigels-com/glew/releases/download/glew-$ver/glew-$ver.zip" -OutFile $zip
+          Expand-Archive $zip -DestinationPath $env:RUNNER_TEMP
+          $glewDir = Join-Path $env:RUNNER_TEMP "glew-$ver"
+          $buildDir = Join-Path $glewDir 'builddir'
+          cmake -S (Join-Path $glewDir 'build' 'cmake') -B $buildDir -G "NMake Makefiles" -DBUILD_SHARED_LIBS=ON -DBUILD_UTILS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$buildDir\install"
+          cmake --build $buildDir --config Release --target install
+          $installDir = Join-Path $buildDir 'install'
+          $binDir = Join-Path $installDir 'bin'
+          $libDir = Join-Path $installDir 'lib'
+          $inc = Join-Path $installDir 'include'
+          "GLEW_BIN_DIR=$binDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "GLEW_INCLUDE_DIR=$inc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "GLEW_LIBRARY=$(Join-Path $libDir 'glew32.lib')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_INCLUDE_PATH=$inc;$env:CMAKE_INCLUDE_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_LIBRARY_PATH=$libDir;$env:CMAKE_LIBRARY_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_PREFIX_PATH=$installDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "$binDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Build OpenBabel
+        shell: pwsh
+        env:
+          ENABLE_TESTS: ${{ matrix.target == 'tests' && 'ON' || 'OFF' }}
+        run: |
+          $srcDir = Join-Path $env:RUNNER_TEMP 'openbabel-src'
+          git clone --depth 1 https://github.com/openbabel/openbabel $srcDir
+          $build = Join-Path $srcDir 'build'
+          cmake -S $srcDir -B $build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$build\install" -DLIBXML2_LIBRARY="$env:LIBXML2_LIBRARY" -DLIBXML2_LIBRARIES="$env:LIBXML2_LIBRARY" -DLIBXML2_INCLUDE_DIR="$env:LIBXML2_INCLUDE_DIR" -DZLIB_LIBRARY="$env:ZLIB_LIBRARY" -DZLIB_INCLUDE_DIR="$env:ZLIB_INCLUDE_DIR" "-DENABLE_TESTS=$env:ENABLE_TESTS" -DBUILD_SHARED=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DOB_USE_PREBUILT_BINARIES=OFF -DOPENBABEL_USE_SYSTEM_INCHI=OFF -DWITH_INCHI=ON
+          Push-Location $build
+          nmake install
+          Pop-Location
+          $obDir = Join-Path $build 'install'
+          $inc = Join-Path $obDir 'include' 'openbabel3'
+          $lib = Join-Path $obDir 'lib' 'openbabel.lib'
+          Copy-Item (Join-Path $obDir 'bin' 'openbabel-3.lib') $lib -Force
+          Copy-Item (Join-Path $obDir 'bin' 'openbabel-3.dll') (Join-Path $obDir 'bin' 'openbabel.dll') -Force
+          $libDir = Join-Path $obDir 'lib'
+          "CMAKE_PREFIX_PATH=$obDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENBABEL3_INCLUDE_DIR=$inc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENBABEL3_LIBRARIES=$lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENBABEL3_LIBRARY_DIRS=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENBABEL_INSTALL_DIR=$obDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "$obDir\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Build xTB
+        shell: cmd
+        run: |
+          setlocal
+          set oneApi=%ProgramFiles(x86)%\Intel\oneAPI
+          set setvars=%oneApi%\setvars.bat
+          if not exist "%setvars%" (
+            if exist "%oneApi%" (
+              for /d %%d in ("%oneApi%\*") do if exist "%%d\oneapi-vars.bat" set setvars=%%d\oneapi-vars.bat & goto :found
+              :found
+            )
+          )
+          if exist "%setvars%" (
+            call "%setvars%" >nul
+          ) else (
+            echo Warning: %setvars% not found
+          )
+          set FC=ifort
+          set srcDir=%RUNNER_TEMP%\xtb-src
+          git clone --depth 1 https://github.com/grimme-lab/xtb %srcDir%
+          set build=%srcDir%\build
+          cmake -S %srcDir% -B %build% -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DBLA_VENDOR=Intel10_64lp
+          cmake --build %build% --config Release --target install
+          set xtbDir=%build%\install
+          set binDir=%xtbDir%\bin
+          set libDir=%xtbDir%\lib
+          set incDir=%xtbDir%\include
+          echo XTB_DIR=%xtbDir%>>%GITHUB_ENV%
+          echo XTB_INCLUDE_DIRS=%incDir%>>%GITHUB_ENV%
+          echo XTB_LIBRARY_DIRS=%libDir%>>%GITHUB_ENV%
+          echo XTB_LIBRARIES=%libDir%\xtb.lib>>%GITHUB_ENV%
+          echo %binDir%>>%GITHUB_PATH%
+      - name: Configure
+        shell: cmd
+        env:
+          ENABLE_TESTS: ${{ matrix.target == 'tests' && 'ON' || 'OFF' }}
+        run: |
+          setlocal
+          set oneApi=%ProgramFiles(x86)%\Intel\oneAPI
+          set setvars=%oneApi%\setvars.bat
+          if not exist "%setvars%" (
+            if exist "%oneApi%" (
+              for /d %%d in ("%oneApi%\*") do if exist "%%d\oneapi-vars.bat" set setvars=%%d\oneapi-vars.bat & goto :found
+              :found
+            )
+          )
+          if exist "%setvars%" (
+            call "%setvars%" >nul
+          ) else (
+            echo Warning: %setvars% not found
+          )
+          set dist=%cd%\scripts\installer\dist
+          cmake -S . -B build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DENABLE_TESTS=%ENABLE_TESTS% -DCMAKE_INSTALL_PREFIX="%dist%" -DENABLE_AVO_PACKAGE=ON -DENABLE_GLSL=ON -DEIGEN3_INCLUDE_DIR=%EIGEN3_INCLUDE_DIR% -DLIBXML2_LIBRARY=%LIBXML2_LIBRARY% -DLIBXML2_INCLUDE_DIR=%LIBXML2_INCLUDE_DIR% -DOPENBABEL3_INCLUDE_DIR=%OPENBABEL3_INCLUDE_DIR% -DOPENBABEL3_LIBRARIES=%OPENBABEL3_LIBRARIES% -DOPENBABEL3_LIBRARY_DIRS=%OPENBABEL3_LIBRARY_DIRS% -DOPENBABEL_INSTALL_DIR=%OPENBABEL_INSTALL_DIR% -DGLEW_INCLUDE_DIR=%GLEW_INCLUDE_DIR% -DGLEW_LIBRARY=%GLEW_LIBRARY% -DENABLE_XTB_OPTTOOL=ON -DXTB_INCLUDE_DIRS=%XTB_INCLUDE_DIRS% -DXTB_LIBRARIES=%XTB_LIBRARIES% -DXTB_LIBRARY_DIRS=%XTB_LIBRARY_DIRS% -DBLA_VENDOR=Intel10_64lp
+      - name: Build
+        shell: cmd
+        run: |
+          setlocal
+          set oneApi=%ProgramFiles(x86)%\Intel\oneAPI
+          set setvars=%oneApi%\setvars.bat
+          if not exist "%setvars%" (
+            if exist "%oneApi%" (
+              for /d %%d in ("%oneApi%\*") do if exist "%%d\oneapi-vars.bat" set setvars=%%d\oneapi-vars.bat & goto :found
+              :found
+            )
+          )
+          if exist "%setvars%" (
+            call "%setvars%" >nul
+          ) else (
+            echo Warning: %setvars% not found
+          )
+          cmake --build build --config Release --target install
+      - name: Create installer
+        if: matrix.target == 'installer'
+        shell: pwsh
+        run: |
+          python scripts/installer/create_installer.py
+      - name: Test
+        if: matrix.target == 'tests'
+        run: ctest --test-dir build -C Release --output-on-failure
+      - name: Upload installer
+        if: matrix.target == 'installer'
+        uses: actions/upload-artifact@v4
+        with:
+          name: avogadro-windows-xtb-installer
+          path: |
+            scripts/installer/avogadro-win32-*.exe
+          if-no-files-found: error

--- a/scripts/installer/create_installer.py
+++ b/scripts/installer/create_installer.py
@@ -132,6 +132,23 @@ def main():
         if dll.exists():
             copy(dll, dist / 'bin')
 
+    xtb_dir = os.environ.get("XTB_DIR")
+    if xtb_dir:
+        xtb = Path(xtb_dir)
+        for f in xtb.glob('bin/*'):
+            if f.suffix.lower() in ('.exe', '.dll'):
+                copy(f, dist / 'bin')
+        share = xtb / 'share' / 'xtb'
+        if share.exists():
+            dest = dist / 'share' / 'xtb'
+            log(f"Copying xTB data from {share} to {dest}")
+            shutil.copytree(share, dest, dirs_exist_ok=True)
+
+    runtime_dir = os.environ.get("FORTRAN_RUNTIME_DIR")
+    if runtime_dir:
+        for dll in Path(runtime_dir).glob('*.dll'):
+            copy(dll, dist / 'bin')
+
     # Copy the GPLv2 license expected by NSIS
     license_src = root.parent.parent / 'COPYING'
     license_dest = dist / 'gpl.txt'


### PR DESCRIPTION
## Summary
- create a separate workflow to build a Windows installer with xTB
- copy xTB binaries and data in the installer when available
- extract Intel oneAPI installers before running bootstrapper
- build xTB from source using Intel Fortran
- include Fortran runtime DLLs in the installer
- set Intel MKL as the BLAS backend during configuration
- fix quoting for `ProgramFiles(x86)` when calling Intel tools
- ensure Fortran compiler path doesn't break CMake
- search for `oneapi-vars.bat` when `setvars.bat` is missing
- avoid failure if the oneAPI directory is absent
- set Intel environment before configure/build steps

## Testing
- `python3 -m py_compile scripts/installer/create_installer.py`


------
https://chatgpt.com/codex/tasks/task_e_685ebc8d7e0883339c867072a8074ffe