### PR TITLE
Fix hair overlay order

### DIFF
--- a/.github/apt-packages.txt
+++ b/.github/apt-packages.txt
@@ -8,4 +8,5 @@ libeigen3-dev
 libopenbabel-dev
 zlib1g-dev
 libglu1-mesa-dev
+libglew-dev
 libqt5test5t64

--- a/.github/apt-packages.txt
+++ b/.github/apt-packages.txt
@@ -9,4 +9,4 @@ libopenbabel-dev
 zlib1g-dev
 libglu1-mesa-dev
 libglew-dev
-libqt5test5t64
+libqt5test5

--- a/libavogadro/src/engines/CMakeLists.txt
+++ b/libavogadro/src/engines/CMakeLists.txt
@@ -61,6 +61,9 @@ avogadro_plugin(dipoleengine dipoleengine.cpp dipolesettingswidget.ui)
 # Simple wire engine - designed for efficiency with really big systems
 avogadro_plugin(simplewireengine simplewireengine.cpp)
 
+# Hair engine - renders animated hair on atoms
+avogadro_plugin(hairengine hairengine.cpp hairsettingswidget.ui)
+
 # QTAIM engine - Quantum Theory of Atoms In Molecules
 avogadro_plugin(qtaimengine qtaimengine.cpp qtaimsettingswidget.ui)
 

--- a/libavogadro/src/engines/hairengine.cpp
+++ b/libavogadro/src/engines/hairengine.cpp
@@ -94,6 +94,7 @@ bool HairEngine::renderOpaque(PainterDevice *pd)
     return false;
 
   glDisable(GL_LIGHTING);
+  glLineWidth(2.0);
 
   double t = m_timer.elapsed() / 1000.0;
   Color *map = colorMap();
@@ -110,15 +111,15 @@ bool HairEngine::renderOpaque(PainterDevice *pd)
     double hairLength = m_lengthFactor * radius;
 
     foreach (const HairStrand &h, hairs) {
-      // Offset the strand base just outside the sphere drawn by BSDYEngine
-      Eigen::Vector3d base = *a->pos() +
-                             h.dir.normalized() * (radius * 1.1);
+      // Offset slightly outside the sphere so lines aren't hidden
+      Eigen::Vector3d base = *a->pos() + h.dir.normalized() * (radius * 1.05);
       Eigen::Vector3d swing = h.dir.cross(Eigen::Vector3d::UnitZ()).normalized();
       Eigen::Vector3d dir = h.dir + swing * 0.2 * qSin(t + h.phase);
       Eigen::Vector3d tip = base + dir.normalized() * hairLength;
       pd->painter()->drawLine(base, tip, 1.0);
     }
   }
+  glLineWidth(1.0);
   glEnable(GL_LIGHTING);
   return true;
 }

--- a/libavogadro/src/engines/hairengine.cpp
+++ b/libavogadro/src/engines/hairengine.cpp
@@ -108,7 +108,8 @@ bool HairEngine::renderOpaque(PainterDevice *pd)
     double hairLength = m_lengthFactor * radius;
 
     foreach (const HairStrand &h, hairs) {
-      Eigen::Vector3d base = *a->pos() + h.dir.normalized() * radius;
+      // Offset the strand base slightly to avoid z-fighting with the atom
+      Eigen::Vector3d base = *a->pos() + h.dir.normalized() * (radius + 0.05);
       Eigen::Vector3d swing = h.dir.cross(Eigen::Vector3d::UnitZ()).normalized();
       Eigen::Vector3d dir = h.dir + swing * 0.2 * qSin(t + h.phase);
       Eigen::Vector3d tip = base + dir.normalized() * hairLength;

--- a/libavogadro/src/engines/hairengine.cpp
+++ b/libavogadro/src/engines/hairengine.cpp
@@ -1,0 +1,165 @@
+
+/**********************************************************************
+  HairEngine - Engine to render animated hair on atoms
+
+  Copyright (C) 2025 OpenAI
+
+  This file is part of the Avogadro molecular editor project.
+  For more information, see <http://avogadro.cc/>
+
+  Avogadro is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  Avogadro is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301, USA.
+**********************************************************************/
+#include "hairengine.h"
+
+#include <avogadro/atom.h>
+#include <avogadro/molecule.h>
+#include <avogadro/painterdevice.h>
+#include <avogadro/color.h>
+#include <openbabel/elements.h>
+#include "ui_hairsettingswidget.h"
+#include <Eigen/Geometry>
+
+#include <QRandomGenerator>
+#include <QtMath>
+#include <QSettings>
+
+namespace Avogadro {
+
+HairSettingsWidget::HairSettingsWidget(QWidget *parent)
+  : QWidget(parent), ui(new Ui::HairSettingsWidget)
+{
+  ui->setupUi(this);
+}
+
+HairSettingsWidget::~HairSettingsWidget()
+{
+  delete ui;
+}
+
+HairEngine::HairEngine(QObject *parent)
+  : Engine(parent), m_lengthFactor(1.5), m_settingsWidget(0)
+{
+  m_timer.start();
+}
+
+Engine *HairEngine::clone() const
+{
+  HairEngine *engine = new HairEngine(parent());
+  engine->setAlias(alias());
+  engine->setEnabled(isEnabled());
+  return engine;
+}
+
+HairEngine::~HairEngine()
+{
+  if (m_settingsWidget)
+    m_settingsWidget->deleteLater();
+}
+
+void HairEngine::setMolecule(Molecule *mol)
+{
+  Engine::setMolecule(mol);
+  m_hair.clear();
+  if (!mol)
+    return;
+  foreach(const Atom *a, mol->atoms()) {
+    QVector<HairStrand> hairs;
+    for (int i = 0; i < 8; ++i) {
+      HairStrand h;
+      h.dir = Eigen::Vector3d::Random().normalized();
+      h.phase = QRandomGenerator::global()->generateDouble() * 2.0 * M_PI;
+      hairs.append(h);
+    }
+    m_hair.insert(a->id(), hairs);
+  }
+}
+
+bool HairEngine::renderOpaque(PainterDevice *pd)
+{
+  if (!pd->molecule())
+    return false;
+
+  double t = m_timer.elapsed() / 1000.0;
+  Color *map = colorMap();
+  if (!map)
+    map = pd->colorMap();
+
+  foreach (const Atom *a, pd->molecule()->atoms()) {
+    QVector<HairStrand> hairs = m_hair.value(a->id());
+    map->setFromPrimitive(a);
+    pd->painter()->setColor(map);
+    double radius = pd->radius(a);
+    if (radius <= 0.0)
+      radius = OpenBabel::OBElements::GetVdwRad(a->atomicNumber());
+    double hairLength = m_lengthFactor * radius;
+
+    foreach (const HairStrand &h, hairs) {
+      Eigen::Vector3d base = *a->pos() + h.dir.normalized() * radius;
+      Eigen::Vector3d swing = h.dir.cross(Eigen::Vector3d::UnitZ()).normalized();
+      Eigen::Vector3d dir = h.dir + swing * 0.2 * qSin(t + h.phase);
+      Eigen::Vector3d tip = base + dir.normalized() * hairLength;
+      pd->painter()->drawLine(base, tip, 1.0);
+    }
+  }
+  return true;
+}
+
+int HairEngine::hairCount(unsigned int atomId) const
+{
+  return m_hair.value(atomId).size();
+}
+
+QWidget *HairEngine::settingsWidget()
+{
+  if (!m_settingsWidget) {
+    m_settingsWidget = new HairSettingsWidget();
+    connect(m_settingsWidget->ui->lengthSlider, SIGNAL(valueChanged(int)),
+            this, SLOT(setLength(int)));
+    connect(m_settingsWidget, SIGNAL(destroyed()),
+            this, SLOT(settingsWidgetDestroyed()));
+    m_settingsWidget->ui->lengthSlider->setValue(static_cast<int>(m_lengthFactor));
+  }
+  return m_settingsWidget;
+}
+
+void HairEngine::settingsWidgetDestroyed()
+{
+  m_settingsWidget = 0;
+}
+
+void HairEngine::setLength(int value)
+{
+  m_lengthFactor = static_cast<double>(value);
+  if (m_settingsWidget)
+    m_settingsWidget->ui->lengthSlider->setValue(value);
+  emit changed();
+}
+
+void HairEngine::writeSettings(QSettings &settings) const
+{
+  Engine::writeSettings(settings);
+  settings.setValue("length", static_cast<int>(m_lengthFactor));
+}
+
+void HairEngine::readSettings(QSettings &settings)
+{
+  Engine::readSettings(settings);
+  int length = settings.value("length", 2).toInt();
+  setLength(length);
+}
+
+} // namespace Avogadro
+

--- a/libavogadro/src/engines/hairengine.cpp
+++ b/libavogadro/src/engines/hairengine.cpp
@@ -110,8 +110,9 @@ bool HairEngine::renderOpaque(PainterDevice *pd)
     double hairLength = m_lengthFactor * radius;
 
     foreach (const HairStrand &h, hairs) {
-      // Offset the strand base slightly to avoid z-fighting with the atom
-      Eigen::Vector3d base = *a->pos() + h.dir.normalized() * (radius + 0.1);
+      // Offset the strand base just outside the sphere drawn by BSDYEngine
+      Eigen::Vector3d base = *a->pos() +
+                             h.dir.normalized() * (radius * 1.1);
       Eigen::Vector3d swing = h.dir.cross(Eigen::Vector3d::UnitZ()).normalized();
       Eigen::Vector3d dir = h.dir + swing * 0.2 * qSin(t + h.phase);
       Eigen::Vector3d tip = base + dir.normalized() * hairLength;

--- a/libavogadro/src/engines/hairengine.cpp
+++ b/libavogadro/src/engines/hairengine.cpp
@@ -109,7 +109,7 @@ bool HairEngine::renderOpaque(PainterDevice *pd)
 
     foreach (const HairStrand &h, hairs) {
       // Offset the strand base slightly to avoid z-fighting with the atom
-      Eigen::Vector3d base = *a->pos() + h.dir.normalized() * (radius + 0.05);
+      Eigen::Vector3d base = *a->pos() + h.dir.normalized() * (radius + 0.1);
       Eigen::Vector3d swing = h.dir.cross(Eigen::Vector3d::UnitZ()).normalized();
       Eigen::Vector3d dir = h.dir + swing * 0.2 * qSin(t + h.phase);
       Eigen::Vector3d tip = base + dir.normalized() * hairLength;

--- a/libavogadro/src/engines/hairengine.cpp
+++ b/libavogadro/src/engines/hairengine.cpp
@@ -85,6 +85,7 @@ void HairEngine::setMolecule(Molecule *mol)
     }
     m_hair.insert(a->id(), hairs);
   }
+  emit changed();
 }
 
 bool HairEngine::renderOpaque(PainterDevice *pd)

--- a/libavogadro/src/engines/hairengine.cpp
+++ b/libavogadro/src/engines/hairengine.cpp
@@ -93,6 +93,8 @@ bool HairEngine::renderOpaque(PainterDevice *pd)
   if (!pd->molecule())
     return false;
 
+  glDisable(GL_LIGHTING);
+
   double t = m_timer.elapsed() / 1000.0;
   Color *map = colorMap();
   if (!map)
@@ -116,6 +118,7 @@ bool HairEngine::renderOpaque(PainterDevice *pd)
       pd->painter()->drawLine(base, tip, 1.0);
     }
   }
+  glEnable(GL_LIGHTING);
   return true;
 }
 

--- a/libavogadro/src/engines/hairengine.h
+++ b/libavogadro/src/engines/hairengine.h
@@ -58,7 +58,7 @@ public:
   Engine *clone() const;
 
   bool renderOpaque(PainterDevice *pd);
-  Layers layers() const { return Engine::Overlay; }
+  Layers layers() const { return Engine::Overlay | Engine::Opaque; }
   void setMolecule(Molecule *molecule);
   Q_INVOKABLE int hairCount(unsigned int atomId) const;
 

--- a/libavogadro/src/engines/hairengine.h
+++ b/libavogadro/src/engines/hairengine.h
@@ -1,0 +1,107 @@
+
+/**********************************************************************
+  HairEngine - Engine for rendering hair on atoms
+
+  Copyright (C) 2025 OpenAI
+
+  This file is part of the Avogadro molecular editor project.
+  For more information, see <http://avogadro.cc/>
+
+  Avogadro is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  Avogadro is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301, USA.
+**********************************************************************/
+#ifndef HAIRENGINE_H
+#define HAIRENGINE_H
+
+#include <avogadro/global.h>
+#include <avogadro/engine.h>
+#include <Eigen/Core>
+#include <QElapsedTimer>
+#include <QMap>
+#include <QVector>
+#include <QSettings>
+#include <QWidget>
+#include <QObject>
+
+namespace Ui {
+class HairSettingsWidget;
+}
+
+namespace Avogadro {
+
+class HairSettingsWidget;
+
+class Atom;
+class Molecule;
+
+class HairEngine : public Engine
+{
+  Q_OBJECT
+  AVOGADRO_ENGINE("Hair", tr("Hair"), tr("Render animated hair on atoms"))
+
+public:
+  explicit HairEngine(QObject *parent = 0);
+  ~HairEngine();
+
+  Engine *clone() const;
+
+  bool renderOpaque(PainterDevice *pd);
+  Layers layers() const { return Engine::Overlay; }
+  void setMolecule(Molecule *molecule);
+  int hairCount(unsigned int atomId) const;
+
+  QWidget *settingsWidget();
+  bool hasSettings() { return true; }
+  void writeSettings(QSettings &settings) const;
+  void readSettings(QSettings &settings);
+
+  void setLength(int value);
+
+private Q_SLOTS:
+  void settingsWidgetDestroyed();
+
+private:
+  struct HairStrand {
+    Eigen::Vector3d dir;
+    double phase;
+  };
+
+  QMap<unsigned int, QVector<HairStrand> > m_hair;
+  QElapsedTimer m_timer;
+  double m_lengthFactor;
+  HairSettingsWidget *m_settingsWidget;
+};
+
+
+class HairSettingsWidget : public QWidget
+{
+public:
+  explicit HairSettingsWidget(QWidget *parent = 0);
+  ~HairSettingsWidget();
+
+  Ui::HairSettingsWidget *ui;
+};
+
+class HairEngineFactory : public QObject, public PluginFactory
+{
+  Q_OBJECT
+  Q_INTERFACES(Avogadro::PluginFactory)
+  Q_PLUGIN_METADATA(IID "net.sourceforge.avogadro.pluginfactory/1.5")
+  AVOGADRO_ENGINE_FACTORY(HairEngine)
+};
+
+} // namespace Avogadro
+
+#endif

--- a/libavogadro/src/engines/hairengine.h
+++ b/libavogadro/src/engines/hairengine.h
@@ -58,7 +58,7 @@ public:
   Engine *clone() const;
 
   bool renderOpaque(PainterDevice *pd);
-  Layers layers() const { return Engine::Overlay | Engine::Opaque; }
+  Layers layers() const { return Engine::Overlay; }
   void setMolecule(Molecule *molecule);
   Q_INVOKABLE int hairCount(unsigned int atomId) const;
 

--- a/libavogadro/src/engines/hairengine.h
+++ b/libavogadro/src/engines/hairengine.h
@@ -59,6 +59,7 @@ public:
 
   bool renderOpaque(PainterDevice *pd);
   Layers layers() const { return Engine::Overlay; }
+public Q_SLOTS:
   void setMolecule(Molecule *molecule);
   Q_INVOKABLE int hairCount(unsigned int atomId) const;
 

--- a/libavogadro/src/engines/hairengine.h
+++ b/libavogadro/src/engines/hairengine.h
@@ -60,7 +60,7 @@ public:
   bool renderOpaque(PainterDevice *pd);
   Layers layers() const { return Engine::Overlay; }
   void setMolecule(Molecule *molecule);
-  int hairCount(unsigned int atomId) const;
+  Q_INVOKABLE int hairCount(unsigned int atomId) const;
 
   QWidget *settingsWidget();
   bool hasSettings() { return true; }

--- a/libavogadro/src/engines/hairsettingswidget.ui
+++ b/libavogadro/src/engines/hairsettingswidget.ui
@@ -1,0 +1,40 @@
+<ui version="4.0">
+ <class>HairSettingsWidget</class>
+ <widget class="QWidget" name="HairSettingsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>200</width>
+    <height>60</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="lengthLabel">
+     <property name="text">
+      <string>Length:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QSlider" name="lengthSlider">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>4</number>
+     </property>
+     <property name="value">
+      <number>2</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/libavogadro/tests/CMakeLists.txt
+++ b/libavogadro/tests/CMakeLists.txt
@@ -59,8 +59,6 @@ foreach (test ${tests})
     ${QT_LIBRARIES}
     ${QT_QTTEST_LIBRARY}
     avogadro
-    $<$<STREQUAL:${test},hairengine>:hairengine>
-    $<$<AND:$<BOOL:${GLEW_FOUND}>,$<STREQUAL:${test},hairengine>>:${GLEW_LIBRARY}>
   )
   add_test(${test}Test ${CMAKE_BINARY_DIR}/bin/${test}test)
   set_tests_properties(${test}Test PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/libavogadro/tests/CMakeLists.txt
+++ b/libavogadro/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(
   ${OPENBABEL2_INCLUDE_DIR}
   ${BOOST_PYTHON_INCLUDES}
   ${PYTHON_INCLUDE_PATH}
+  $<$<BOOL:${GLEW_FOUND}>:${GLEW_INCLUDE_DIR}>
 )
 
 link_directories(
@@ -59,6 +60,7 @@ foreach (test ${tests})
     ${QT_QTTEST_LIBRARY}
     avogadro
     $<$<STREQUAL:${test},hairengine>:hairengine>
+    $<$<AND:$<BOOL:${GLEW_FOUND}>,$<STREQUAL:${test},hairengine>>:${GLEW_LIBRARY}>
   )
   add_test(${test}Test ${CMAKE_BINARY_DIR}/bin/${test}test)
   set_tests_properties(${test}Test PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/libavogadro/tests/CMakeLists.txt
+++ b/libavogadro/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(
   ${CMAKE_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${libavogadro_BINARY_DIR}/src
+  ${libavogadro_BINARY_DIR}/src/engines/hairengine_autogen/include
   $<$<BOOL:${EIGEN3_FOUND}>:${EIGEN3_INCLUDE_DIR}>
   $<$<NOT:$<BOOL:${EIGEN3_FOUND}>>:${EIGEN2_INCLUDE_DIR}>
   ${OPENBABEL2_INCLUDE_DIR}
@@ -38,6 +39,7 @@ set(tests
   moleculefile
   neighborlist
   addremovehydrogens
+  hairengine
 )
 if(XTB_FOUND)
   list(APPEND tests xtbopttool xtbphysics)
@@ -55,13 +57,16 @@ foreach (test ${tests})
     ${OPENBABEL2_LIBRARIES}
     ${QT_LIBRARIES}
     ${QT_QTTEST_LIBRARY}
-    avogadro)
+    avogadro
+    $<$<STREQUAL:${test},hairengine>:hairengine>
+  )
   add_test(${test}Test ${CMAKE_BINARY_DIR}/bin/${test}test)
   set_tests_properties(${test}Test PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
   set_property(SOURCE ${test_SRCS} PROPERTY LABELS avogadro)
   set_property(TARGET ${test}test PROPERTY LABELS avogadro)
   set_property(TEST ${test}Test PROPERTY LABELS avogadro)
 endforeach ()
+
 
 if(XTB_FOUND)
   include_directories(${XTB_INCLUDE_DIRS})

--- a/libavogadro/tests/hairenginetest.cpp
+++ b/libavogadro/tests/hairenginetest.cpp
@@ -4,7 +4,7 @@
 #include <avogadro/pluginmanager.h>
 #include <avogadro/engine.h>
 #include <avogadro/atom.h>
-#include "../src/engines/hairengine.h"
+#include <QMetaObject>
 #include <avogadro/molecule.h>
 #include <Eigen/Geometry>
 
@@ -40,12 +40,17 @@ void HairEngineTest::pluginLoaded()
   mol.addAtom(1, Eigen::Vector3d(1, 0, 0));
   engine->setMolecule(&mol);
 
-  HairEngine *hair = qobject_cast<HairEngine *>(engine);
-  QVERIFY(hair != nullptr);
-  for (unsigned int i = 0; i < mol.numAtoms(); ++i)
-    QCOMPARE(hair->hairCount(mol.atom(i)->id()), 8);
+  for (unsigned int i = 0; i < mol.numAtoms(); ++i) {
+    int count = 0;
+    bool ok = QMetaObject::invokeMethod(engine, "hairCount",
+                                        Qt::DirectConnection,
+                                        Q_RETURN_ARG(int, count),
+                                        Q_ARG(unsigned int, mol.atom(i)->id()));
+    QVERIFY(ok);
+    QCOMPARE(count, 8);
+  }
 
-  delete hair;
+  delete engine;
 }
 
 QTEST_MAIN(HairEngineTest)

--- a/libavogadro/tests/hairenginetest.cpp
+++ b/libavogadro/tests/hairenginetest.cpp
@@ -1,0 +1,52 @@
+#include "config.h"
+#include <QtTest>
+#include <QDir>
+#include <avogadro/pluginmanager.h>
+#include <avogadro/engine.h>
+#include <avogadro/atom.h>
+#include "../src/engines/hairengine.h"
+#include <avogadro/molecule.h>
+#include <Eigen/Geometry>
+
+using namespace Avogadro;
+
+class HairEngineTest : public QObject
+{
+  Q_OBJECT
+private slots:
+  void pluginLoaded();
+};
+
+void HairEngineTest::pluginLoaded()
+{
+  QStringList pluginDirs = PluginManager::instance()->pluginPath();
+  bool pluginExists = false;
+  foreach (const QString &dir, pluginDirs) {
+    QDir d(dir);
+    QStringList files = d.entryList(QStringList() << "*hairengine*", QDir::Files);
+    if (!files.isEmpty()) {
+      pluginExists = true;
+      break;
+    }
+  }
+  if (!pluginExists)
+    QSKIP("hairengine plugin not built");
+
+  Engine *engine = PluginManager::instance()->engine("Hair", this);
+  QVERIFY(engine != nullptr);
+
+  Molecule mol;
+  mol.addAtom(6, Eigen::Vector3d(0, 0, 0));
+  mol.addAtom(1, Eigen::Vector3d(1, 0, 0));
+  engine->setMolecule(&mol);
+
+  HairEngine *hair = qobject_cast<HairEngine *>(engine);
+  QVERIFY(hair != nullptr);
+  for (unsigned int i = 0; i < mol.numAtoms(); ++i)
+    QCOMPARE(hair->hairCount(mol.atom(i)->id()), 8);
+
+  delete hair;
+}
+
+QTEST_MAIN(HairEngineTest)
+#include "moc_hairenginetest.cpp"


### PR DESCRIPTION
## Summary
- render hair lines in the overlay layer so they're not hidden by spheres
- use van der Waals radii when sizing hairs
- move settings widget implementation to cpp so tests can include the header
- verify each atom gets 8 hairs in the unit test
- grow hair from whichever display shell is outermost

## Testing
- `cmake .. -DENABLE_TESTS=ON`
- `cmake --build . --target hairenginetest`
- `ctest -R hairengine --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_685ebd7399e4833395c8aca096e7904a