### PR TITLE
Reintegrate old ORCA code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,36 @@ jobs:
           if [ "${{ matrix.xtb }}" = "on" ]; then
             sudo apt-get install -y xtb libxtb-dev
           fi
+      - name: Build OpenBabel
+        run: |
+          src="$RUNNER_TEMP/openbabel-src"
+          mkdir -p "$src"
+          curl -L https://github.com/thosoo/openbabel/tarball/master | tar -xz --strip-components=1 -C "$src"
+          cmake -S "$src" -B "$src/build" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$src/build/install" \
+            -DBUILD_SHARED=ON \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DOB_USE_PREBUILT_BINARIES=OFF \
+            -DOPENBABEL_USE_SYSTEM_INCHI=OFF \
+            -DWITH_INCHI=ON
+          cmake --build "$src/build" --target install -j2
+          obdir="$src/build/install"
+          inc="$obdir/include/openbabel3"
+          libdir="$obdir/lib"
+          lib="$libdir/libopenbabel.so"
+          sudo ldconfig "$libdir"
+          echo "LD_LIBRARY_PATH=$libdir:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LDFLAGS=-L$libdir $LDFLAGS" >> "$GITHUB_ENV"
+          echo "CMAKE_PREFIX_PATH=$obdir:$CMAKE_PREFIX_PATH" >> "$GITHUB_ENV"
+          cmake_dir="$libdir/cmake/openbabel3"
+          echo "OpenBabel3_DIR=$cmake_dir" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_PATH=$libdir/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
+          echo "OPENBABEL3_INCLUDE_DIR=$inc" >> "$GITHUB_ENV"
+          echo "OPENBABEL3_LIBRARIES=$lib" >> "$GITHUB_ENV"
+          echo "OPENBABEL3_LIBRARY_DIRS=$libdir" >> "$GITHUB_ENV"
+          echo "OPENBABEL_INSTALL_DIR=$obdir" >> "$GITHUB_ENV"
+          echo "$obdir/bin" >> "$GITHUB_PATH"
       - name: Configure
         run: |
           cmake -S . -B build \

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -122,7 +122,7 @@ jobs:
           ENABLE_TESTS: ${{ matrix.target == 'tests' && 'ON' || 'OFF' }}
         run: |
           $srcDir = Join-Path $env:RUNNER_TEMP 'openbabel-src'
-          git clone --depth 1 https://github.com/openbabel/openbabel $srcDir
+          git clone --depth 1 https://github.com/thosoo/openbabel $srcDir
           $build = Join-Path $srcDir 'build'
           cmake -S $srcDir -B $build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$build\install" -DLIBXML2_LIBRARY="$env:LIBXML2_LIBRARY" -DLIBXML2_LIBRARIES="$env:LIBXML2_LIBRARY" -DLIBXML2_INCLUDE_DIR="$env:LIBXML2_INCLUDE_DIR" -DZLIB_LIBRARY="$env:ZLIB_LIBRARY" -DZLIB_INCLUDE_DIR="$env:ZLIB_INCLUDE_DIR" "-DENABLE_TESTS=$env:ENABLE_TESTS" -DBUILD_SHARED=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DOB_USE_PREBUILT_BINARIES=OFF -DOPENBABEL_USE_SYSTEM_INCHI=OFF -DWITH_INCHI=ON
           Push-Location $build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,13 +246,23 @@ find_package(OpenBabel3 REQUIRED) # find and setup OpenBabel
 include(CheckCXXSourceCompiles)
 # Ensure the test uses the OpenBabel include directories
 set(_ob_prev_includes ${CMAKE_REQUIRED_INCLUDES})
-set(CMAKE_REQUIRED_INCLUDES ${OPENBABEL3_INCLUDE_DIRS})
+# Prefer the variable exported by OpenBabel3's config, but
+# fall back to the one from our FindOpenBabel3.cmake module.
+if(DEFINED OpenBabel3_INCLUDE_DIRS)
+  set(_ob_inc_dirs ${OpenBabel3_INCLUDE_DIRS})
+else()
+  set(_ob_inc_dirs ${OPENBABEL3_INCLUDE_DIRS})
+endif()
+set(CMAKE_REQUIRED_INCLUDES ${_ob_inc_dirs})
+set(_ob_prev_flags ${CMAKE_REQUIRED_FLAGS})
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${CMAKE_CXX_FLAGS}")
 check_cxx_source_compiles(
   "#include <openbabel/generic.h>
    using namespace OpenBabel;
    int main(){ OBOrcaSpecData data; OBOrcaNearIRData nird; return 0; }"
   HAVE_OB_ORCA_SPEC_DATA)
 set(CMAKE_REQUIRED_INCLUDES ${_ob_prev_includes})
+set(CMAKE_REQUIRED_FLAGS ${_ob_prev_flags})
 if(HAVE_OB_ORCA_SPEC_DATA)
   add_definitions(-DHAVE_OB_ORCA_SPEC_DATA)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,31 +242,6 @@ find_package(Eigen3 REQUIRED) # find and setup Eigen3 if available
 find_package(ZLIB REQUIRED)
 find_package(OpenBabel3 REQUIRED) # find and setup OpenBabel
 
-# Check if OpenBabel provides ORCA spectral data classes
-include(CheckCXXSourceCompiles)
-# Ensure the test uses the OpenBabel include directories
-set(_ob_prev_includes ${CMAKE_REQUIRED_INCLUDES})
-# Prefer the variable exported by OpenBabel3's config, but
-# fall back to the one from our FindOpenBabel3.cmake module.
-if(DEFINED OpenBabel3_INCLUDE_DIRS)
-  set(_ob_inc_dirs ${OpenBabel3_INCLUDE_DIRS})
-else()
-  set(_ob_inc_dirs ${OPENBABEL3_INCLUDE_DIRS})
-endif()
-set(CMAKE_REQUIRED_INCLUDES ${_ob_inc_dirs})
-set(_ob_prev_flags ${CMAKE_REQUIRED_FLAGS})
-set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${CMAKE_CXX_FLAGS}")
-check_cxx_source_compiles(
-  "#include <openbabel/generic.h>
-   using namespace OpenBabel;
-   int main(){ OBOrcaSpecData data; OBOrcaNearIRData nird; return 0; }"
-  HAVE_OB_ORCA_SPEC_DATA)
-set(CMAKE_REQUIRED_INCLUDES ${_ob_prev_includes})
-set(CMAKE_REQUIRED_FLAGS ${_ob_prev_flags})
-if(HAVE_OB_ORCA_SPEC_DATA)
-  add_definitions(-DHAVE_OB_ORCA_SPEC_DATA)
-endif()
-
 if (Q_WS_X11)
   find_package(X11 REQUIRED) # avogadro/src/main.cpp calls XInitThread().
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,17 @@ find_package(Eigen3 REQUIRED) # find and setup Eigen3 if available
 find_package(ZLIB REQUIRED)
 find_package(OpenBabel3 REQUIRED) # find and setup OpenBabel
 
+# Check if OpenBabel provides ORCA spectral data classes
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles(
+  "#include <openbabel/generic.h>
+   using namespace OpenBabel;
+   int main(){ OBOrcaSpecData data; OBOrcaNearIRData nird; return 0; }"
+  HAVE_OB_ORCA_SPEC_DATA)
+if(HAVE_OB_ORCA_SPEC_DATA)
+  add_definitions(-DHAVE_OB_ORCA_SPEC_DATA)
+endif()
+
 if (Q_WS_X11)
   find_package(X11 REQUIRED) # avogadro/src/main.cpp calls XInitThread().
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,11 +244,15 @@ find_package(OpenBabel3 REQUIRED) # find and setup OpenBabel
 
 # Check if OpenBabel provides ORCA spectral data classes
 include(CheckCXXSourceCompiles)
+# Ensure the test uses the OpenBabel include directories
+set(_ob_prev_includes ${CMAKE_REQUIRED_INCLUDES})
+set(CMAKE_REQUIRED_INCLUDES ${OPENBABEL3_INCLUDE_DIRS})
 check_cxx_source_compiles(
   "#include <openbabel/generic.h>
    using namespace OpenBabel;
    int main(){ OBOrcaSpecData data; OBOrcaNearIRData nird; return 0; }"
   HAVE_OB_ORCA_SPEC_DATA)
+set(CMAKE_REQUIRED_INCLUDES ${_ob_prev_includes})
 if(HAVE_OB_ORCA_SPEC_DATA)
   add_definitions(-DHAVE_OB_ORCA_SPEC_DATA)
 endif()

--- a/libavogadro/examples/thirdPartyExtensions/03-ViewPlane/viewplaneextension.cpp
+++ b/libavogadro/examples/thirdPartyExtensions/03-ViewPlane/viewplaneextension.cpp
@@ -34,7 +34,7 @@
 #include <Eigen/Geometry>
 
 #include <QtGui/QAction>
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QMessageBox>
 
 using namespace Avogadro;
 

--- a/libavogadro/examples/thirdPartyExtensions/04-RotateSelection/rotateselectionextension.cpp
+++ b/libavogadro/examples/thirdPartyExtensions/04-RotateSelection/rotateselectionextension.cpp
@@ -36,7 +36,7 @@
 
 #include <QtCore/QDebug>
 #include <QtGui/QAction>
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QMessageBox>
 
 #include "rotateselectiondialog.h"
 

--- a/libavogadro/src/extensions/spectra/CMakeLists.txt
+++ b/libavogadro/src/extensions/spectra/CMakeLists.txt
@@ -21,14 +21,14 @@ set(spectraextension_SRCS
   uv.cpp
   cd.cpp
   raman.cpp
-  emission.cpp
-  absorption.cpp
   abstract_orcaspec.cpp
   energy.cpp
 )
 
 if(HAVE_OB_ORCA_SPEC_DATA)
-  list(APPEND spectraextension_SRCS nearir.cpp)
+  list(APPEND spectraextension_SRCS emission.cpp absorption.cpp nearir.cpp)
+else()
+  message(STATUS "Building without ORCA spectral support")
 endif()
 
 avogadro_plugin_nogl(spectraextension

--- a/libavogadro/src/extensions/spectra/CMakeLists.txt
+++ b/libavogadro/src/extensions/spectra/CMakeLists.txt
@@ -10,6 +10,27 @@ avogadro_plugin_nogl(vibrationextension
   vibrationwidget.ui)
 
 ### Spectra
+set(spectraextension_SRCS
+  spectraextension.cpp
+  spectradialog.cpp
+  spectratype.cpp
+  abstract_ir.cpp
+  ir.cpp
+  nmr.cpp
+  dos.cpp
+  uv.cpp
+  cd.cpp
+  raman.cpp
+  emission.cpp
+  absorption.cpp
+  abstract_orcaspec.cpp
+  energy.cpp
+)
+
+if(HAVE_OB_ORCA_SPEC_DATA)
+  list(APPEND spectraextension_SRCS nearir.cpp)
+endif()
+
 avogadro_plugin_nogl(spectraextension
-  "spectraextension.cpp;spectradialog.cpp;spectratype.cpp;abstract_ir.cpp;ir.cpp;nearir.cpp;nmr.cpp;dos.cpp;uv.cpp;cd.cpp;raman.cpp;emission.cpp;absorption.cpp;abstract_orcaspec.cpp;;energy.cpp"
+  "${spectraextension_SRCS}"
   "spectradialog.ui;tab_ir_raman.ui;tab_nmr.ui;tab_dos.ui;tab_uv.ui;tab_cd.ui;tab_orcaspec.ui;tab_energy.ui")

--- a/libavogadro/src/extensions/spectra/CMakeLists.txt
+++ b/libavogadro/src/extensions/spectra/CMakeLists.txt
@@ -23,13 +23,10 @@ set(spectraextension_SRCS
   raman.cpp
   abstract_orcaspec.cpp
   energy.cpp
+  emission.cpp
+  absorption.cpp
+  nearir.cpp
 )
-
-if(HAVE_OB_ORCA_SPEC_DATA)
-  list(APPEND spectraextension_SRCS emission.cpp absorption.cpp nearir.cpp)
-else()
-  message(STATUS "Building without ORCA spectral support")
-endif()
 
 avogadro_plugin_nogl(spectraextension
   "${spectraextension_SRCS}"

--- a/libavogadro/src/extensions/spectra/CMakeLists.txt
+++ b/libavogadro/src/extensions/spectra/CMakeLists.txt
@@ -11,5 +11,5 @@ avogadro_plugin_nogl(vibrationextension
 
 ### Spectra
 avogadro_plugin_nogl(spectraextension
-  "spectraextension.cpp;spectradialog.cpp;spectratype.cpp;abstract_ir.cpp;ir.cpp;nmr.cpp;dos.cpp;uv.cpp;cd.cpp;raman.cpp;emission.cpp;absorption.cpp;abstract_orcaspec.cpp;;energy.cpp"
+  "spectraextension.cpp;spectradialog.cpp;spectratype.cpp;abstract_ir.cpp;ir.cpp;nearir.cpp;nmr.cpp;dos.cpp;uv.cpp;cd.cpp;raman.cpp;emission.cpp;absorption.cpp;abstract_orcaspec.cpp;;energy.cpp"
   "spectradialog.ui;tab_ir_raman.ui;tab_nmr.ui;tab_dos.ui;tab_uv.ui;tab_cd.ui;tab_orcaspec.ui;tab_energy.ui")

--- a/libavogadro/src/extensions/spectra/absorption.cpp
+++ b/libavogadro/src/extensions/spectra/absorption.cpp
@@ -18,6 +18,7 @@
  ***********************************************************************/
 
 #include <openbabel/generic.h>
+#ifdef HAVE_OB_ORCA_SPEC_DATA
 
 #include "absorption.h"
 #include "spectradialog.h"
@@ -74,8 +75,115 @@ void OrcaAbsSpectra::readSettings() {
 
 bool OrcaAbsSpectra::checkForData(Molecule * mol)
 {
-    Q_UNUSED(mol);
-    return false;
+    OpenBabel::OBMol obmol = mol->OBMol();
+    OpenBabel::OBOrcaSpecData *osd =
+      static_cast<OpenBabel::OBOrcaSpecData*>(obmol.GetData("OrcaSpectraData"));
+
+    if (!osd)
+        return false;
+    if (!osd->GetSpecData() && osd->GetAbsCombined().size() == 0)
+        return false;
+    if (osd->GetAbsEDipole().size() == 0 && osd->GetAbsCombined().size() == 0)
+        return false;
+
+    m_wavelength.resize(0);
+    m_wavenumber.resize(0);
+    m_energy.resize(0);
+    m_edipole.clear();
+    m_velosity.clear();
+    m_combined.clear();
+    m_D2.clear();
+    m_M2.clear();
+    m_Q2.clear();
+
+    std::vector<double> tmp_edipole, tmp_velosity, tmp_combined,
+        tmp_D2, tmp_M2, tmp_Q2;
+
+    m_wavelength = osd->GetAbsWavelengths();
+    getSortIdx(m_wavelength);
+
+    tmp_edipole = osd->GetAbsEDipole();
+    if (osd->GetAbsVelocity().size() != 0)
+        tmp_velosity = osd->GetAbsVelocity();
+    if (osd->GetAbsCombined().size() != 0) {
+        tmp_combined = osd->GetAbsCombined();
+        tmp_D2 = osd->GetAbsD2();
+        tmp_M2 = osd->GetAbsM2();
+        tmp_Q2 = osd->GetAbsQ2();
+    }
+
+    for (uint i = 0; i < tmp_edipole.size(); i++) {
+        m_edipole.push_back(tmp_edipole[m_idx[i]]);
+        if (tmp_velosity.size())
+            m_velosity.push_back(tmp_velosity[m_idx[i]]);
+        if (osd->GetAbsCombined().size() != 0) {
+            m_combined.push_back(tmp_combined[m_idx[i]]);
+            m_D2.push_back(tmp_D2[m_idx[i]]);
+            m_M2.push_back(tmp_M2[m_idx[i]]);
+            m_Q2.push_back(tmp_Q2[m_idx[i]]);
+        }
+    }
+
+    for (uint i = 0; i < m_wavelength.size(); i++) {
+        m_wavenumber.push_back(1.e7 / m_wavelength.at(i));
+        m_energy.push_back(1.e7 / (8065.54477 * m_wavelength.at(i)));
+    }
+
+    m_xList.clear();
+    m_yList.clear();
+
+    switch (m_XUnit) {
+    case WAVELENGTH:
+        m_XminIdx = m_wavelength.size() - 1;
+        m_xmin = m_xmin_org = m_wavelength.at(m_XminIdx);
+        m_XmaxIdx = 0;
+        m_xmax = m_xmax_org = m_wavelength.at(m_XmaxIdx);
+        for (int i = m_XmaxIdx; i <= m_XminIdx; i++)
+            m_xList.append(m_wavelength.at(i));
+        break;
+    case ENERGY_eV:
+        m_XminIdx = 0;
+        m_xmin = m_energy.at(m_XminIdx);
+        m_XmaxIdx = m_energy.size() - 1;
+        m_xmax = m_energy.at(m_XmaxIdx);
+        m_xmin_org = eV_to_nm / m_xmin;
+        m_xmax_org = eV_to_nm / m_xmax;
+        for (int i = m_XminIdx; i <= m_XmaxIdx; i++)
+            m_xList.append(m_energy.at(i));
+        break;
+    case WAVENUMBER:
+        m_XminIdx = 0;
+        m_xmin = m_wavenumber.at(m_XminIdx);
+        m_XmaxIdx = m_wavenumber.size() - 1;
+        m_xmax = m_wavenumber.at(m_XmaxIdx);
+        m_xmin_org = cm_1_to_nm / m_xmin;
+        m_xmax_org = cm_1_to_nm / m_xmax;
+        for (int i = m_XminIdx; i <= m_XmaxIdx; i++)
+            m_xList.append(m_wavenumber.at(i));
+        break;
+    default:
+        break; // never hit here
+    }
+
+    ui.spin_Xmin->setValue(m_xmin);
+    ui.spin_Xmax->setValue(m_xmax);
+
+    ui.combo_OrcaSpecType->clear();
+    if (m_edipole.size() != 0)
+        ui.combo_OrcaSpecType->addItem("Transition Electric dipole");
+    if (m_velosity.size() != 0)
+        ui.combo_OrcaSpecType->addItem("Transition Electric velosity");
+    if (m_D2.size() != 0)
+        ui.combo_OrcaSpecType->addItem("Electric dipole/total");
+    if (m_M2.size() != 0)
+        ui.combo_OrcaSpecType->addItem("Magnetic dipole/total");
+    if (m_Q2.size() != 0)
+        ui.combo_OrcaSpecType->addItem("Quadrupole dipole/total");
+    if (m_combined.size() != 0)
+        ui.combo_OrcaSpecType->addItem("Combined");
+
+    OrcaSpecTypeChanged(ui.combo_OrcaSpecType->currentText());
+    return true;
 }
 
 void OrcaAbsSpectra::setupPlot(PlotWidget * plot) {
@@ -134,6 +242,6 @@ QString OrcaAbsSpectra::getDataStream(PlotObject *plotObject)
     }
 }
 
-
+#endif // HAVE_OB_ORCA_SPEC_DATA
 
 }

--- a/libavogadro/src/extensions/spectra/absorption.cpp
+++ b/libavogadro/src/extensions/spectra/absorption.cpp
@@ -23,7 +23,6 @@
 #include "spectradialog.h"
 
 #include <QtWidgets/QMessageBox>
-#include <openbabel/oborcadata.h>
 #include <QtCore/QDebug>
 
 #include <openbabel/mol.h>

--- a/libavogadro/src/extensions/spectra/absorption.cpp
+++ b/libavogadro/src/extensions/spectra/absorption.cpp
@@ -18,6 +18,7 @@
  ***********************************************************************/
 
 #include <openbabel/generic.h>
+#include <openbabel/oborcadata.h>
 
 #include "absorption.h"
 #include "spectradialog.h"

--- a/libavogadro/src/extensions/spectra/absorption.cpp
+++ b/libavogadro/src/extensions/spectra/absorption.cpp
@@ -244,4 +244,4 @@ QString OrcaAbsSpectra::getDataStream(PlotObject *plotObject)
 
 #endif // HAVE_OB_ORCA_SPEC_DATA
 
-}
+} // namespace Avogadro

--- a/libavogadro/src/extensions/spectra/absorption.cpp
+++ b/libavogadro/src/extensions/spectra/absorption.cpp
@@ -23,6 +23,7 @@
 #include "spectradialog.h"
 
 #include <QtWidgets/QMessageBox>
+#include <openbabel/oborcadata.h>
 #include <QtCore/QDebug>
 
 #include <openbabel/mol.h>
@@ -72,38 +73,30 @@ void OrcaAbsSpectra::readSettings() {
 //    m_EnergyShift = ui.spin_EnergyShift;
 }
 
-bool OrcaAbsSpectra::checkForData(Molecule * mol)
-{
-    OpenBabel::OBMol obmol = mol->OBMol();
-    OpenBabel::OBOrcaSpecData *osd =
-      static_cast<OpenBabel::OBOrcaSpecData*>(obmol.GetData("OrcaSpectraData"));
+bool OrcaAbsSpectra::checkForData(Molecule * mol) {
 
-    if (!osd)
-        return false;
-    if (!osd->GetSpecData() && osd->GetAbsCombined().size() == 0)
-        return false;
-    if (osd->GetAbsEDipole().size() == 0 && osd->GetAbsCombined().size() == 0)
-        return false;
+    OpenBabel::OBMol obmol = mol->OBMol();
+    //OpenBabel::OBOrcaSpecData *osd = static_cast<OpenBabel::OBOrcaSpecData*>(obmol.GetData("OrcaSpectraData"));
+    OpenBabel::OBOrcaSpecData *osd = static_cast<OpenBabel::OBOrcaSpecData*>(obmol.GetData(OpenBabel::OBGenericDataType::CustomData0));
+
+    if (!osd) return false;
+    if (!osd->GetSpecData()) return false;
+    if (osd->GetAbsEDipole().size() == 0) return false;
 
     m_wavelength.resize(0);
     m_wavenumber.resize(0);
     m_energy.resize(0);
-    m_edipole.clear();
-    m_velosity.clear();
-    m_combined.clear();
-    m_D2.clear();
-    m_M2.clear();
-    m_Q2.clear();
+    m_edipole.resize(0);
 
-    std::vector<double> tmp_edipole, tmp_velosity, tmp_combined,
-        tmp_D2, tmp_M2, tmp_Q2;
+    std::vector<double> tmp_edipole, tmp_velosity, tmp_combined, tmp_D2, tmp_M2, tmp_Q2;
 
+    // OK, we have valid data, so store them for later
     m_wavelength = osd->GetAbsWavelengths();
+    // sort for ascending wavelength
     getSortIdx(m_wavelength);
 
     tmp_edipole = osd->GetAbsEDipole();
-    if (osd->GetAbsVelocity().size() != 0)
-        tmp_velosity = osd->GetAbsVelocity();
+    if (osd->GetAbsVelocity().size() != 0)  tmp_velosity = osd->GetAbsVelocity();
     if (osd->GetAbsCombined().size() != 0) {
         tmp_combined = osd->GetAbsCombined();
         tmp_D2 = osd->GetAbsD2();
@@ -111,76 +104,75 @@ bool OrcaAbsSpectra::checkForData(Molecule * mol)
         tmp_Q2 = osd->GetAbsQ2();
     }
 
-    for (uint i = 0; i < tmp_edipole.size(); i++) {
+    // resort data
+    for (uint i = 0; i < tmp_edipole.size(); i++){
         m_edipole.push_back(tmp_edipole[m_idx[i]]);
-        if (tmp_velosity.size())
-            m_velosity.push_back(tmp_velosity[m_idx[i]]);
+    }
+    for (uint i = 0; i < tmp_edipole.size(); i++){
         if (osd->GetAbsCombined().size() != 0) {
-            m_combined.push_back(tmp_combined[m_idx[i]]);
-            m_D2.push_back(tmp_D2[m_idx[i]]);
-            m_M2.push_back(tmp_M2[m_idx[i]]);
-            m_Q2.push_back(tmp_Q2[m_idx[i]]);
+          m_combined.push_back(tmp_combined[m_idx[i]]);
+          m_D2.push_back(tmp_D2[m_idx[i]]);
+          m_M2.push_back(tmp_M2[m_idx[i]]);
+          m_Q2.push_back(tmp_Q2[m_idx[i]]);
         }
     }
 
-    for (uint i = 0; i < m_wavelength.size(); i++) {
-        m_wavenumber.push_back(1.e7 / m_wavelength.at(i));
-        m_energy.push_back(1.e7 / (8065.54477 * m_wavelength.at(i)));
+    // convert nm to cm-1 and eV
+    for (uint i = 0; i < m_wavelength.size(); i++){
+        m_wavenumber.push_back(1.e7/m_wavelength.at(i));
+        m_energy.push_back(1.e7/(8065.54477*m_wavelength.at(i)));
     }
 
+    // Store in member vars
     m_xList.clear();
     m_yList.clear();
-
     switch (m_XUnit) {
+
     case WAVELENGTH:
-        m_XminIdx = m_wavelength.size() - 1;
+        m_XminIdx = m_wavelength.size()-1;
         m_xmin = m_xmin_org = m_wavelength.at(m_XminIdx);
         m_XmaxIdx = 0;
         m_xmax = m_xmax_org = m_wavelength.at(m_XmaxIdx);
-        for (int i = m_XmaxIdx; i <= m_XminIdx; i++)
+        for (int i = m_XmaxIdx; i <= m_XminIdx; i++){
             m_xList.append(m_wavelength.at(i));
+        }
         break;
     case ENERGY_eV:
         m_XminIdx = 0;
         m_xmin = m_energy.at(m_XminIdx);
-        m_XmaxIdx = m_energy.size() - 1;
+        m_XmaxIdx = m_energy.size()-1;
         m_xmax = m_energy.at(m_XmaxIdx);
         m_xmin_org = eV_to_nm / m_xmin;
         m_xmax_org = eV_to_nm / m_xmax;
-        for (int i = m_XminIdx; i <= m_XmaxIdx; i++)
+        for (int i = m_XminIdx; i <= m_XmaxIdx; i++){
             m_xList.append(m_energy.at(i));
+        }
         break;
     case WAVENUMBER:
         m_XminIdx = 0;
         m_xmin = m_wavenumber.at(m_XminIdx);
-        m_XmaxIdx = m_wavenumber.size() - 1;
+        m_XmaxIdx = m_wavenumber.size()-1;
         m_xmax = m_wavenumber.at(m_XmaxIdx);
-        m_xmin_org = cm_1_to_nm / m_xmin;
-        m_xmax_org = cm_1_to_nm / m_xmax;
-        for (int i = m_XminIdx; i <= m_XmaxIdx; i++)
+        m_xmin_org = cm_1_to_nm/m_xmin;
+        m_xmax_org = cm_1_to_nm/m_xmax;
+
+        for (int i = m_XminIdx; i <= m_XmaxIdx; i++){
             m_xList.append(m_wavenumber.at(i));
+        }
         break;
     default:
         break; // never hit here
     }
-
     ui.spin_Xmin->setValue(m_xmin);
     ui.spin_Xmax->setValue(m_xmax);
 
     ui.combo_OrcaSpecType->clear();
-    if (m_edipole.size() != 0)
-        ui.combo_OrcaSpecType->addItem("Transition Electric dipole");
-    if (m_velosity.size() != 0)
-        ui.combo_OrcaSpecType->addItem("Transition Electric velosity");
-    if (m_D2.size() != 0)
-        ui.combo_OrcaSpecType->addItem("Electric dipole/total");
-    if (m_M2.size() != 0)
-        ui.combo_OrcaSpecType->addItem("Magnetic dipole/total");
-    if (m_Q2.size() != 0)
-        ui.combo_OrcaSpecType->addItem("Quadrupole dipole/total");
-    if (m_combined.size() != 0)
-        ui.combo_OrcaSpecType->addItem("Combined");
-
+    if (m_edipole.size() != 0) ui.combo_OrcaSpecType->addItem("Transition Electric dipole");
+    if (m_velosity.size() != 0) ui.combo_OrcaSpecType->addItem("Transition Electric velosity");
+    if (m_D2.size() != 0) ui.combo_OrcaSpecType->addItem("Electric dipole/total");
+    if (m_M2.size() != 0) ui.combo_OrcaSpecType->addItem("Magnetic dipole/total");
+    if (m_Q2.size() != 0) ui.combo_OrcaSpecType->addItem("Quadrupole dipole/total");
+    if (m_combined.size() != 0) ui.combo_OrcaSpecType->addItem("Combined");
     OrcaSpecTypeChanged(ui.combo_OrcaSpecType->currentText());
     return true;
 }
@@ -241,5 +233,6 @@ QString OrcaAbsSpectra::getDataStream(PlotObject *plotObject)
     }
 }
 
-} // namespace Avogadro
 
+
+}

--- a/libavogadro/src/extensions/spectra/absorption.cpp
+++ b/libavogadro/src/extensions/spectra/absorption.cpp
@@ -18,7 +18,6 @@
  ***********************************************************************/
 
 #include <openbabel/generic.h>
-#include <openbabel/oborcadata.h>
 
 #include "absorption.h"
 #include "spectradialog.h"

--- a/libavogadro/src/extensions/spectra/absorption.cpp
+++ b/libavogadro/src/extensions/spectra/absorption.cpp
@@ -18,7 +18,6 @@
  ***********************************************************************/
 
 #include <openbabel/generic.h>
-#ifdef HAVE_OB_ORCA_SPEC_DATA
 
 #include "absorption.h"
 #include "spectradialog.h"
@@ -244,4 +243,3 @@ QString OrcaAbsSpectra::getDataStream(PlotObject *plotObject)
 
 } // namespace Avogadro
 
-#endif // HAVE_OB_ORCA_SPEC_DATA

--- a/libavogadro/src/extensions/spectra/absorption.cpp
+++ b/libavogadro/src/extensions/spectra/absorption.cpp
@@ -242,6 +242,6 @@ QString OrcaAbsSpectra::getDataStream(PlotObject *plotObject)
     }
 }
 
-#endif // HAVE_OB_ORCA_SPEC_DATA
-
 } // namespace Avogadro
+
+#endif // HAVE_OB_ORCA_SPEC_DATA

--- a/libavogadro/src/extensions/spectra/emission.cpp
+++ b/libavogadro/src/extensions/spectra/emission.cpp
@@ -18,6 +18,7 @@
  ***********************************************************************/
 
 #include <openbabel/generic.h>
+#include <openbabel/oborcadata.h>
 
 #include "emission.h"
 #include "spectradialog.h"

--- a/libavogadro/src/extensions/spectra/emission.cpp
+++ b/libavogadro/src/extensions/spectra/emission.cpp
@@ -18,7 +18,6 @@
  ***********************************************************************/
 
 #include <openbabel/generic.h>
-#ifdef HAVE_OB_ORCA_SPEC_DATA
 
 #include "emission.h"
 #include "spectradialog.h"
@@ -238,4 +237,3 @@ QString OrcaEmissionSpectra::getDataStream(PlotObject *plotObject)
 
 } // namespace Avogadro
 
-#endif // HAVE_OB_ORCA_SPEC_DATA

--- a/libavogadro/src/extensions/spectra/emission.cpp
+++ b/libavogadro/src/extensions/spectra/emission.cpp
@@ -23,7 +23,6 @@
 #include "spectradialog.h"
 
 #include <QtWidgets/QMessageBox>
-#include <openbabel/oborcadata.h>
 #include <QtCore/QDebug>
 
 #include <openbabel/mol.h>

--- a/libavogadro/src/extensions/spectra/emission.cpp
+++ b/libavogadro/src/extensions/spectra/emission.cpp
@@ -236,6 +236,6 @@ QString OrcaEmissionSpectra::getDataStream(PlotObject *plotObject)
     }
 }
 
-#endif // HAVE_OB_ORCA_SPEC_DATA
-
 } // namespace Avogadro
+
+#endif // HAVE_OB_ORCA_SPEC_DATA

--- a/libavogadro/src/extensions/spectra/emission.cpp
+++ b/libavogadro/src/extensions/spectra/emission.cpp
@@ -18,11 +18,12 @@
  ***********************************************************************/
 
 #include <openbabel/generic.h>
+#ifdef HAVE_OB_ORCA_SPEC_DATA
 
 #include "emission.h"
 #include "spectradialog.h"
 
-#include <QtWidgets/QMessageBox>
+#include <QtGui/QMessageBox>
 #include <QtCore/QDebug>
 
 #include <openbabel/mol.h>
@@ -73,10 +74,109 @@ void OrcaEmissionSpectra::readSettings() {
 //    m_EnergyShift = ui.spin_EnergyShift;
 }
 
-bool OrcaEmissionSpectra::checkForData(Molecule * mol)
-{
-    Q_UNUSED(mol);
-    return false;
+bool OrcaEmissionSpectra::checkForData(Molecule * mol) {
+
+    OpenBabel::OBMol obmol = mol->OBMol();
+    OpenBabel::OBOrcaSpecData *osd = static_cast<OpenBabel::OBOrcaSpecData*>(obmol.GetData("OrcaSpectraData"));
+
+    if (!osd) return false;
+    if (!osd->GetSpecData()) return false;
+    if (osd->GetEmEDipole().size() == 0) return false;
+
+    m_wavelength.resize(0);
+    m_wavenumber.resize(0);
+    m_energy.resize(0);
+    m_edipole.resize(0);
+
+    std::vector<double> tmp_edipole, tmp_velosity, tmp_combined, tmp_D2, tmp_M2, tmp_Q2;
+
+    // OK, we have valid data, so store them for later
+    m_wavelength = osd->GetEmWavelengths();
+    // sort for ascending wavelength
+    getSortIdx(m_wavelength);
+
+    tmp_edipole = osd->GetEmEDipole();
+    if (osd->GetEmVelosity().size() != 0)  tmp_velosity = osd->GetEmVelosity();
+    if (osd->GetEmCombined().size() != 0) {
+        tmp_combined = osd->GetEmCombined();
+        tmp_D2 = osd->GetEmD2();
+        tmp_M2 = osd->GetEmM2();
+        tmp_Q2 = osd->GetEmQ2();
+    }
+
+    // resort data
+    for (uint i = 0; i < tmp_edipole.size(); i++){
+        m_edipole.push_back(tmp_edipole[m_idx[i]]);
+    }
+    for (uint i = 0; i < tmp_edipole.size(); i++){
+        if (osd->GetEmCombined().size() != 0) {
+            m_combined.push_back(tmp_combined[m_idx[i]]);
+            m_D2.push_back(tmp_D2[m_idx[i]]);
+            m_M2.push_back(tmp_M2[m_idx[i]]);
+            m_Q2.push_back(tmp_Q2[m_idx[i]]);
+        }
+    }
+
+    // convert nm to cm-1 and eV
+    for (uint i = 0; i < m_wavelength.size(); i++){
+        m_wavenumber.push_back(1.e7/m_wavelength.at(i));
+        m_energy.push_back(1.e7/(8065.54477*m_wavelength.at(i)));
+    }
+
+    // Store in member vars
+    m_xList.clear();
+    m_yList.clear();
+
+    //    m_XUnit =  XUnits(ui.combo_XUnit->currentIndex());
+    switch (m_XUnit) {
+
+    case WAVELENGTH:
+        m_XminIdx = m_wavelength.size()-1;
+        m_xmin = m_xmin_org = m_wavelength.at(m_XminIdx);
+        m_XmaxIdx = 0;
+        m_xmax = m_xmax_org = m_wavelength.at(m_XmaxIdx);
+        for (int i = m_XmaxIdx; i <= m_XminIdx; i++){
+            m_xList.append(m_wavelength.at(i));
+        }
+        break;
+    case ENERGY_eV:
+        m_XminIdx = 0;
+        m_xmin = m_energy.at(m_XminIdx);
+        m_XmaxIdx = m_energy.size()-1;
+        m_xmax = m_energy.at(m_XmaxIdx);
+        m_xmin_org = eV_to_nm / m_xmin;
+        m_xmax_org = eV_to_nm / m_xmax;
+        for (int i = m_XminIdx; i <= m_XmaxIdx; i++){
+            m_xList.append(m_energy.at(i));
+        }
+        break;
+    case WAVENUMBER:
+        m_XminIdx = 0;
+        m_xmin = m_wavenumber.at(m_XminIdx);
+        m_XmaxIdx = m_wavenumber.size()-1;
+        m_xmax = m_wavenumber.at(m_XmaxIdx);
+        m_xmin_org = cm_1_to_nm/m_xmin;
+        m_xmax_org = cm_1_to_nm/m_xmax;
+
+        for (int i = m_XminIdx; i <= m_XmaxIdx; i++){
+            m_xList.append(m_wavenumber.at(i));
+        }
+        break;
+    default:
+        break; // never hit here
+    }
+    ui.spin_Xmin->setValue(m_xmin);
+    ui.spin_Xmax->setValue(m_xmax);
+
+    ui.combo_OrcaSpecType->clear();
+    if (m_edipole.size() != 0) ui.combo_OrcaSpecType->addItem("Transition Electric dipole");
+    if (m_velosity.size() != 0) ui.combo_OrcaSpecType->addItem("Transition Electric velosity");
+    if (m_D2.size() != 0) ui.combo_OrcaSpecType->addItem("Electric dipole/total");
+    if (m_M2.size() != 0) ui.combo_OrcaSpecType->addItem("Magnetic dipole/total");
+    if (m_Q2.size() != 0) ui.combo_OrcaSpecType->addItem("Quadrupole dipole/total");
+    if (m_combined.size() != 0) ui.combo_OrcaSpecType->addItem("Combined");
+    OrcaSpecTypeChanged(ui.combo_OrcaSpecType->currentText());
+    return true;
 }
 
 void OrcaEmissionSpectra::setupPlot(PlotWidget * plot) {
@@ -136,6 +236,6 @@ QString OrcaEmissionSpectra::getDataStream(PlotObject *plotObject)
     }
 }
 
-
+#endif // HAVE_OB_ORCA_SPEC_DATA
 
 }

--- a/libavogadro/src/extensions/spectra/emission.cpp
+++ b/libavogadro/src/extensions/spectra/emission.cpp
@@ -18,7 +18,6 @@
  ***********************************************************************/
 
 #include <openbabel/generic.h>
-#include <openbabel/oborcadata.h>
 
 #include "emission.h"
 #include "spectradialog.h"

--- a/libavogadro/src/extensions/spectra/emission.cpp
+++ b/libavogadro/src/extensions/spectra/emission.cpp
@@ -23,7 +23,7 @@
 #include "emission.h"
 #include "spectradialog.h"
 
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QMessageBox>
 #include <QtCore/QDebug>
 
 #include <openbabel/mol.h>

--- a/libavogadro/src/extensions/spectra/emission.cpp
+++ b/libavogadro/src/extensions/spectra/emission.cpp
@@ -238,4 +238,4 @@ QString OrcaEmissionSpectra::getDataStream(PlotObject *plotObject)
 
 #endif // HAVE_OB_ORCA_SPEC_DATA
 
-}
+} // namespace Avogadro

--- a/libavogadro/src/extensions/spectra/emission.cpp
+++ b/libavogadro/src/extensions/spectra/emission.cpp
@@ -23,6 +23,7 @@
 #include "spectradialog.h"
 
 #include <QtWidgets/QMessageBox>
+#include <openbabel/oborcadata.h>
 #include <QtCore/QDebug>
 
 #include <openbabel/mol.h>

--- a/libavogadro/src/extensions/spectra/ir.cpp
+++ b/libavogadro/src/extensions/spectra/ir.cpp
@@ -25,7 +25,6 @@
 
 #include <openbabel/mol.h>
 #include <openbabel/generic.h>
-#include <openbabel/oborcadata.h>
 
 using namespace std;
 

--- a/libavogadro/src/extensions/spectra/ir.cpp
+++ b/libavogadro/src/extensions/spectra/ir.cpp
@@ -25,6 +25,7 @@
 
 #include <openbabel/mol.h>
 #include <openbabel/generic.h>
+#include <openbabel/oborcadata.h>
 
 using namespace std;
 

--- a/libavogadro/src/extensions/spectra/ir.cpp
+++ b/libavogadro/src/extensions/spectra/ir.cpp
@@ -83,6 +83,25 @@ namespace Avogadro {
     // OK, we have valid vibrations, so store them for later
     vector<double> wavenumbers = vibrations->GetFrequencies();
     vector<double> intensities = vibrations->GetIntensities();
+    qDebug() << "has IR data " << wavenumbers.size();
+
+    // check if there are also data from a nearIR spectrum
+    OpenBabel::OBOrcaNearIRData *ond = static_cast<OpenBabel::OBOrcaNearIRData*>(obmol.GetData("OrcaNearIRSpectraData"));
+    if (ond) {
+        qDebug() << "has also nearIR data " << wavenumbers.size();
+
+        if (ond->GetNearIRData())  {
+            // OK, we have valid vibrations, so store them for later
+            vector<double> wavenumbersIR = ond->GetFrequencies();
+            vector<double> intensitiesIR = ond->GetIntensities();
+            for (unsigned int i = 0; i < intensitiesIR.size(); i++) {
+                if (wavenumbersIR.at(i) < 4000.) {
+                    wavenumbers.push_back(wavenumbersIR.at(i));
+                    intensities.push_back(intensitiesIR.at(i));
+                }
+            }
+        }
+    }
 
     // Case where there are no intensities, set all intensities to an arbitrary value, i.e. 1.0
     if (wavenumbers.size() > 0 && intensities.size() == 0) {

--- a/libavogadro/src/extensions/spectra/ir.cpp
+++ b/libavogadro/src/extensions/spectra/ir.cpp
@@ -86,6 +86,7 @@ namespace Avogadro {
     qDebug() << "has IR data " << wavenumbers.size();
 
     // check if there are also data from a nearIR spectrum
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     OpenBabel::OBOrcaNearIRData *ond = static_cast<OpenBabel::OBOrcaNearIRData*>(obmol.GetData("OrcaNearIRSpectraData"));
     if (ond) {
         qDebug() << "has also nearIR data " << wavenumbers.size();
@@ -102,6 +103,7 @@ namespace Avogadro {
             }
         }
     }
+#endif
 
     // Case where there are no intensities, set all intensities to an arbitrary value, i.e. 1.0
     if (wavenumbers.size() > 0 && intensities.size() == 0) {

--- a/libavogadro/src/extensions/spectra/ir.cpp
+++ b/libavogadro/src/extensions/spectra/ir.cpp
@@ -86,7 +86,6 @@ namespace Avogadro {
     qDebug() << "has IR data " << wavenumbers.size();
 
     // check if there are also data from a nearIR spectrum
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     OpenBabel::OBOrcaNearIRData *ond = static_cast<OpenBabel::OBOrcaNearIRData*>(obmol.GetData("OrcaNearIRSpectraData"));
     if (ond) {
         qDebug() << "has also nearIR data " << wavenumbers.size();
@@ -103,7 +102,6 @@ namespace Avogadro {
             }
         }
     }
-#endif
 
     // Case where there are no intensities, set all intensities to an arbitrary value, i.e. 1.0
     if (wavenumbers.size() > 0 && intensities.size() == 0) {

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -4,6 +4,7 @@
 
 #include <openbabel/mol.h>
 #include <openbabel/generic.h>
+#include <openbabel/oborcadata.h>
 
 #include <vector>
 

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -1,0 +1,168 @@
+#include "nearir.h"
+#include <QtGui/QMessageBox>
+#include <QtCore/QDebug>
+
+#include <openbabel/mol.h>
+#include <openbabel/generic.h>
+#ifdef HAVE_OB_ORCA_SPEC_DATA
+#include <openbabel/generic.h>
+using namespace std;
+
+namespace Avogadro {
+
+NearIRSpectra::NearIRSpectra(SpectraDialog *parent ) :
+    AbstractIRSpectra( parent )
+{
+    ui.group_ramanIntensities->hide();
+//    ui.combo_yaxis->addItem(tr("Transmittance (%)"));
+//    ui.combo_yaxis->addItem(tr("Absorbance (%)"));
+    ui.combo_yaxis->setCurrentIndex(1);
+    readSettings();
+}
+NearIRSpectra::~NearIRSpectra() {
+    // TODO: Anything to delete?
+    writeSettings();
+}
+void NearIRSpectra::readSettings() {
+    QSettings settings; // Already set up in avogadro/src/main.cpp
+    m_scale = settings.value("spectra/NearIR/scale", 1.0).toDouble();
+    ui.spin_scale->setValue(m_scale);
+    updateScaleSlider(m_scale);
+    m_fwhm = settings.value("spectra/NearIR/gaussianWidth",0.0).toDouble();
+    ui.spin_FWHM->setValue(m_fwhm);
+    updateFWHMSlider(m_fwhm);
+    ui.cb_labelPeaks->setChecked(settings.value("spectra/NearIR/labelPeaks",false).toBool());
+    QString yunit = settings.value("spectra/NearIR/yAxisUnits",tr("Absorbance (%)")).toString();
+    updateYAxis(yunit);
+    if (yunit == "Transmittance (%)")
+        ui.combo_yaxis->setCurrentIndex(0);
+
+    ui.combo_lineShape->setCurrentIndex(settings.value("spectra/NearIR/lineShape", GAUSSIAN).toInt());
+    m_lineShape = LineShape(ui.combo_lineShape->currentIndex());
+    ui.spin_nPoints->setValue(settings.value("spectra/NearIR/nPoints",10).toInt());
+    emit plotDataChanged();
+}
+void NearIRSpectra::writeSettings()
+{
+    QSettings settings; // Already set up in avogadro/src/main.cpp
+
+    settings.setValue("spectra/NearIR/scale", m_scale);
+    settings.setValue("spectra/NearIR/gaussianWidth", m_fwhm);
+    settings.setValue("spectra/NearIR/labelPeaks", ui.cb_labelPeaks->isChecked());
+    settings.setValue("spectra/NearIR/yAxisUnits", ui.combo_yaxis->currentText());
+    settings.setValue("spectra/NearIR/lineShape", ui.combo_lineShape->currentIndex());
+    settings.setValue("spectra/NearIR/nPoints", ui.spin_nPoints->value());
+}
+
+bool NearIRSpectra::checkForData(Molecule * mol) {
+    OpenBabel::OBMol obmol = mol->OBMol();
+//    OpenBabel::OBVibrationData *vibrations = static_cast<OpenBabel::OBVibrationData*>(obmol.GetData(OpenBabel::OBGenericDataType::VibrationData));
+    OpenBabel::OBOrcaNearIRData *ond = static_cast<OpenBabel::OBOrcaNearIRData*>(obmol.GetData("OrcaNearIRSpectraData"));
+
+    if (!ond) return false;
+    if (!ond->GetNearIRData()) return false;
+
+    // OK, we have valid vibrations, so store them for later
+    vector<double> wavenumbers = ond->GetFrequencies();
+    vector<double> intensities = ond->GetIntensities();
+
+    // Case where there are no intensities, set all intensities to an arbitrary value, i.e. 1.0
+    if (wavenumbers.size() > 0 && intensities.size() == 0) {
+        // Warn user
+        QMessageBox::information(m_dialog, tr("No intensities"), tr("The vibration data in the molecule you have loaded does not have any intensity data. Intensities have been set to an arbitrary value for visualization."));
+        for (uint i = 0; i < wavenumbers.size(); i++) {
+            intensities.push_back(1.0);
+        }
+    }
+
+    // Normalize intensities into transmittances
+    double maxIntensity=0;
+    for (unsigned int i = 0; i < intensities.size(); i++) {
+        if (intensities.at(i) >= maxIntensity) {
+            maxIntensity = intensities.at(i);
+        }
+    }
+
+    vector<double> absorbances;
+
+    for (unsigned int i = 0; i < intensities.size(); i++) {
+        double t = intensities.at(i);
+        if (maxIntensity != 0) {
+            t = t / maxIntensity; 	// Normalize
+        }
+        t *= 100.0;		// Convert to percent
+        absorbances.push_back(t);
+    }
+
+    // Store in member vars
+    m_xList.clear();
+    m_xList_orig.clear();
+    m_yList.clear();
+    for (uint i = 0; i < wavenumbers.size(); i++){
+        double w = wavenumbers.at(i);
+        m_xList.append(w*scale(w));
+        m_xList_orig.append(w);
+        m_yList.append(absorbances.at(i));
+    }
+
+    return true;
+}
+void NearIRSpectra::setupPlot(PlotWidget * plot) {
+  plot->setDefaultLimits( 3500.0, 400.0, 0.0, 100.0 );
+  plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Wavenumber (cm<sup>-1</sup>)"));
+  plot->axis(PlotWidget::LeftAxis)->setLabel(m_yaxis);
+}
+
+void NearIRSpectra::getCalculatedPlotObject(PlotObject *plotObject) {
+  AbstractIRSpectra::getCalculatedPlotObject(plotObject);
+  // Convert to transmittance?
+  if (ui.combo_yaxis->currentIndex() == 0) {
+    for(int i = 0; i< plotObject->points().size(); i++) {
+      double transmittance = 100 - plotObject->points().at(i)->y();
+      plotObject->points().at(i)->setY(transmittance);
+    }
+  }
+  // Add labels for gaussians?
+  if ((m_fwhm != 0.0) && (ui.cb_labelPeaks->isChecked())) {
+    if (ui.combo_yaxis->currentIndex() == 1) {
+      assignGaussianLabels(plotObject, true, m_labelYThreshold);
+      m_dialog->labelsUp(true);
+    } else {
+      assignGaussianLabels(plotObject, false, 100-m_labelYThreshold);
+      m_dialog->labelsUp(false);
+    }
+  }
+}
+
+
+void NearIRSpectra::setImportedData(const QList<double> & xList, const QList<double> & yList) {
+  m_xList_imp = xList;
+  m_yList_imp = yList;
+
+  // Convert y values to percents from fraction, if necessary...
+  bool convert = true;
+  for (int i = 0; i < m_yList_imp.size(); i++) {
+    if (m_yList_imp.at(i) > 1.5) { // If transmittances exist greater than this, they're already in percent.
+      convert = false;
+      break;
+    }
+  }
+  if (convert) {
+    for (int i = 0; i < m_yList_imp.size(); i++) {
+      double tmp = m_yList_imp.at(i);
+      tmp *= 100;
+      m_yList_imp.replace(i, tmp);
+    }
+  }
+}
+
+QString NearIRSpectra::getTSV() {
+  return SpectraType::getTSV("Frequencies", "Intensities");
+}
+
+QString NearIRSpectra::getDataStream(PlotObject *plotObject)
+{
+    return SpectraType::getDataStream (plotObject, "Frequencies", "Intensities");
+}
+#endif // HAVE_OB_ORCA_SPEC_DATA
+}

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -3,6 +3,7 @@
 #include <QtCore/QDebug>
 
 #include <openbabel/mol.h>
+#include <openbabel/oborcadata.h>
 #include <openbabel/generic.h>
 
 #include <vector>

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -1,6 +1,5 @@
 #include "nearir.h"
 #include <QtWidgets/QMessageBox>
-#include <openbabel/oborcadata.h>
 #include <QtCore/QDebug>
 
 #include <openbabel/mol.h>

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -5,7 +5,8 @@
 #include <openbabel/mol.h>
 #include <openbabel/generic.h>
 
-#ifdef HAVE_OB_ORCA_SPEC_DATA
+#include <vector>
+
 using namespace std;
 
 namespace Avogadro {
@@ -165,4 +166,3 @@ QString NearIRSpectra::getDataStream(PlotObject *plotObject)
     return SpectraType::getDataStream (plotObject, "Frequencies", "Intensities");
 }
 } // namespace Avogadro
-#endif // HAVE_OB_ORCA_SPEC_DATA

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -1,5 +1,6 @@
 #include "nearir.h"
 #include <QtWidgets/QMessageBox>
+#include <openbabel/oborcadata.h>
 #include <QtCore/QDebug>
 
 #include <openbabel/mol.h>

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -3,7 +3,6 @@
 #include <QtCore/QDebug>
 
 #include <openbabel/mol.h>
-#include <openbabel/oborcadata.h>
 #include <openbabel/generic.h>
 
 #include <vector>

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -4,7 +4,6 @@
 
 #include <openbabel/mol.h>
 #include <openbabel/generic.h>
-#include <openbabel/oborcadata.h>
 
 #include <vector>
 

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -4,8 +4,8 @@
 
 #include <openbabel/mol.h>
 #include <openbabel/generic.h>
+
 #ifdef HAVE_OB_ORCA_SPEC_DATA
-#include <openbabel/generic.h>
 using namespace std;
 
 namespace Avogadro {

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -164,5 +164,5 @@ QString NearIRSpectra::getDataStream(PlotObject *plotObject)
 {
     return SpectraType::getDataStream (plotObject, "Frequencies", "Intensities");
 }
+} // namespace Avogadro
 #endif // HAVE_OB_ORCA_SPEC_DATA
-}

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -1,5 +1,5 @@
 #include "nearir.h"
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QMessageBox>
 #include <QtCore/QDebug>
 
 #include <openbabel/mol.h>

--- a/libavogadro/src/extensions/spectra/nearir.h
+++ b/libavogadro/src/extensions/spectra/nearir.h
@@ -1,0 +1,28 @@
+#ifndef SPECTRATYPE_NEARIR_H
+#define SPECTRATYPE_NEARIR_H
+
+#include "abstract_ir.h"
+
+namespace Avogadro {
+
+class NearIRSpectra : public AbstractIRSpectra
+{
+    Q_OBJECT
+
+public:
+    NearIRSpectra( SpectraDialog *parent = 0 );
+    ~NearIRSpectra();
+
+    void writeSettings();
+    void readSettings();
+
+    bool checkForData(Molecule* mol);
+    void setupPlot(PlotWidget * plot);
+
+    void getCalculatedPlotObject(PlotObject *plotObject);
+    void setImportedData(const QList<double> & xList, const QList<double> & yList);
+    QString getTSV();
+    QString getDataStream(PlotObject *plotObject);
+};
+}
+#endif // SPECTRATYPE_NEARIR_H

--- a/libavogadro/src/extensions/spectra/nearir.h
+++ b/libavogadro/src/extensions/spectra/nearir.h
@@ -3,8 +3,6 @@
 
 #include "abstract_ir.h"
 
-#ifdef HAVE_OB_ORCA_SPEC_DATA
-
 namespace Avogadro {
 
 class NearIRSpectra : public AbstractIRSpectra
@@ -27,5 +25,4 @@ public:
     QString getDataStream(PlotObject *plotObject);
 };
 }
-#endif // HAVE_OB_ORCA_SPEC_DATA
 #endif // SPECTRATYPE_NEARIR_H

--- a/libavogadro/src/extensions/spectra/nearir.h
+++ b/libavogadro/src/extensions/spectra/nearir.h
@@ -3,6 +3,8 @@
 
 #include "abstract_ir.h"
 
+#ifdef HAVE_OB_ORCA_SPEC_DATA
+
 namespace Avogadro {
 
 class NearIRSpectra : public AbstractIRSpectra
@@ -25,4 +27,5 @@ public:
     QString getDataStream(PlotObject *plotObject);
 };
 }
+#endif // HAVE_OB_ORCA_SPEC_DATA
 #endif // SPECTRATYPE_NEARIR_H

--- a/libavogadro/src/extensions/spectra/spectradialog.cpp
+++ b/libavogadro/src/extensions/spectra/spectradialog.cpp
@@ -21,7 +21,9 @@
 #include "spectratype.h"
 
 #include "ir.h"
+#ifdef HAVE_OB_ORCA_SPEC_DATA
 #include "nearir.h"
+#endif
 #include "nmr.h"
 #include "dos.h"
 #include "uv.h"
@@ -70,7 +72,9 @@ namespace Avogadro {
 
     // Set up spectra variables
     m_spectra_ir = new IRSpectra(this);
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     m_spectra_nearir = new NearIRSpectra(this);
+#endif
     m_spectra_nmr = new NMRSpectra(this);
     m_spectra_dos = new DOSSpectra(this);
     m_spectra_uv = new UVSpectra(this);
@@ -160,7 +164,9 @@ namespace Avogadro {
   {
     writeSettings();
     delete m_spectra_ir;
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     delete m_spectra_nearir;
+#endif
     delete m_spectra_nmr;
     delete m_spectra_dos;
     delete m_spectra_uv;
@@ -179,7 +185,9 @@ namespace Avogadro {
     m_molecule = molecule;
 
     m_spectra_ir->clear();
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     m_spectra_nearir->clear();
+#endif
     m_spectra_nmr->clear();
     m_spectra_dos->clear();
     m_spectra_uv->clear();
@@ -213,11 +221,15 @@ namespace Avogadro {
     }
 
     // Check for NearIR data
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     bool hasNearIR = m_spectra_nearir->checkForData(m_molecule);
     if (hasNearIR) {
       ui.combo_spectra->addItem(tr("NearInfrared", "Overtone and Combined spectra"));
       ui.tab_widget->addTab(m_spectra_nearir->getTabWidget(), tr("&Near Infrared Spectra Settings"));
     }
+#else
+    bool hasNearIR = false;
+#endif
 
     // Check for NMR data
     bool hasNMR = m_spectra_nmr->checkForData(m_molecule);
@@ -1159,8 +1171,10 @@ namespace Avogadro {
   {
     if (m_spectra == "Infrared")
       return m_spectra_ir;
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     else if (m_spectra == "NearInfrared")
         return m_spectra_nearir;
+#endif
     else if (m_spectra == "NMR")
       return m_spectra_nmr;
     else if (m_spectra == "DOS")

--- a/libavogadro/src/extensions/spectra/spectradialog.cpp
+++ b/libavogadro/src/extensions/spectra/spectradialog.cpp
@@ -21,6 +21,7 @@
 #include "spectratype.h"
 
 #include "ir.h"
+#include "nearir.h"
 #include "nmr.h"
 #include "dos.h"
 #include "uv.h"
@@ -69,6 +70,7 @@ namespace Avogadro {
 
     // Set up spectra variables
     m_spectra_ir = new IRSpectra(this);
+    m_spectra_nearir = new NearIRSpectra(this);
     m_spectra_nmr = new NMRSpectra(this);
     m_spectra_dos = new DOSSpectra(this);
     m_spectra_uv = new UVSpectra(this);
@@ -158,6 +160,7 @@ namespace Avogadro {
   {
     writeSettings();
     delete m_spectra_ir;
+    delete m_spectra_nearir;
     delete m_spectra_nmr;
     delete m_spectra_dos;
     delete m_spectra_uv;
@@ -176,6 +179,7 @@ namespace Avogadro {
     m_molecule = molecule;
 
     m_spectra_ir->clear();
+    m_spectra_nearir->clear();
     m_spectra_nmr->clear();
     m_spectra_dos->clear();
     m_spectra_uv->clear();
@@ -206,6 +210,13 @@ namespace Avogadro {
     if (hasIR) {
       ui.combo_spectra->addItem(tr("Infrared", "Infrared spectra option"));
       ui.tab_widget->addTab(m_spectra_ir->getTabWidget(), tr("&Infrared Spectra Settings"));
+    }
+
+    // Check for NearIR data
+    bool hasNearIR = m_spectra_nearir->checkForData(m_molecule);
+    if (hasNearIR) {
+      ui.combo_spectra->addItem(tr("NearInfrared", "Overtone and Combined spectra"));
+      ui.tab_widget->addTab(m_spectra_nearir->getTabWidget(), tr("&Near Infrared Spectra Settings"));
     }
 
     // Check for NMR data
@@ -264,7 +275,7 @@ namespace Avogadro {
       ui.tab_widget->addTab(m_spectra_emission->getTabWidget(), tr("&Emission Settings"));
     }
     // Change this when other spectra are added!!
-    if (!hasIR && !hasNMR && !hasDOS && !hasUV && !hasCD && !hasRaman && !hasEnergy && !hasAbsorption && !hasEmission) { // Actions if there are no spectra loaded
+    if (!hasIR && !hasNearIR && !hasNMR && !hasDOS && !hasUV && !hasCD && !hasRaman && !hasEnergy && !hasAbsorption && !hasEmission) { // Actions if there are no spectra loaded
       qWarning() << "SpectraDialog::setMolecule: No spectra available!";
       ui.combo_spectra->addItem(tr("No data"));
       ui.push_colorCalculated->setEnabled(false);
@@ -1148,6 +1159,8 @@ namespace Avogadro {
   {
     if (m_spectra == "Infrared")
       return m_spectra_ir;
+    else if (m_spectra == "NearInfrared")
+        return m_spectra_nearir;
     else if (m_spectra == "NMR")
       return m_spectra_nmr;
     else if (m_spectra == "DOS")

--- a/libavogadro/src/extensions/spectra/spectradialog.cpp
+++ b/libavogadro/src/extensions/spectra/spectradialog.cpp
@@ -21,9 +21,7 @@
 #include "spectratype.h"
 
 #include "ir.h"
-#ifdef HAVE_OB_ORCA_SPEC_DATA
 #include "nearir.h"
-#endif
 #include "nmr.h"
 #include "dos.h"
 #include "uv.h"
@@ -72,19 +70,15 @@ namespace Avogadro {
 
     // Set up spectra variables
     m_spectra_ir = new IRSpectra(this);
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     m_spectra_nearir = new NearIRSpectra(this);
-#endif
     m_spectra_nmr = new NMRSpectra(this);
     m_spectra_dos = new DOSSpectra(this);
     m_spectra_uv = new UVSpectra(this);
     m_spectra_cd = new CDSpectra(this);
     m_spectra_raman = new RamanSpectra(this);
     m_spectra_energy = new EnergySpectra(this);
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     m_spectra_absorption = new OrcaAbsSpectra(this);
     m_spectra_emission = new OrcaEmissionSpectra(this);
-#endif
     // Initialize vars
     m_schemes = new QList<QHash<QString, QVariant> >;
 
@@ -166,19 +160,15 @@ namespace Avogadro {
   {
     writeSettings();
     delete m_spectra_ir;
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     delete m_spectra_nearir;
-#endif
     delete m_spectra_nmr;
     delete m_spectra_dos;
     delete m_spectra_uv;
     delete m_spectra_cd;
     delete m_spectra_raman;
     delete m_spectra_energy;
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     delete m_spectra_emission;
     delete m_spectra_absorption;
-#endif
   }
 
   void SpectraDialog::setMolecule(Molecule *molecule)
@@ -189,19 +179,15 @@ namespace Avogadro {
     m_molecule = molecule;
 
     m_spectra_ir->clear();
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     m_spectra_nearir->clear();
-#endif
     m_spectra_nmr->clear();
     m_spectra_dos->clear();
     m_spectra_uv->clear();
     m_spectra_cd->clear();
     m_spectra_raman->clear();
     m_spectra_energy->clear();
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     m_spectra_absorption->clear();
     m_spectra_emission->clear();
-#endif
     updatePlot();
 
     // set the filename in the image export widget
@@ -227,15 +213,11 @@ namespace Avogadro {
     }
 
     // Check for NearIR data
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     bool hasNearIR = m_spectra_nearir->checkForData(m_molecule);
     if (hasNearIR) {
       ui.combo_spectra->addItem(tr("NearInfrared", "Overtone and Combined spectra"));
       ui.tab_widget->addTab(m_spectra_nearir->getTabWidget(), tr("&Near Infrared Spectra Settings"));
     }
-#else
-    bool hasNearIR = false;
-#endif
 
     // Check for NMR data
     bool hasNMR = m_spectra_nmr->checkForData(m_molecule);
@@ -280,7 +262,6 @@ namespace Avogadro {
       ui.tab_widget->addTab(m_spectra_raman->getTabWidget(), tr("&Raman Settings"));
     }
 
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     // Check for ORCA absorption data
     bool hasAbsorption = m_spectra_absorption->checkForData(m_molecule);
     if (hasAbsorption) {
@@ -293,10 +274,6 @@ namespace Avogadro {
       ui.combo_spectra->addItem(tr("Emission", "Emission spectrum"));
       ui.tab_widget->addTab(m_spectra_emission->getTabWidget(), tr("&Emission Settings"));
     }
-#else
-    bool hasAbsorption = false;
-    bool hasEmission = false;
-#endif
     // Change this when other spectra are added!!
     if (!hasIR && !hasNearIR && !hasNMR && !hasDOS && !hasUV && !hasCD && !hasRaman && !hasEnergy && !hasAbsorption && !hasEmission) { // Actions if there are no spectra loaded
       qWarning() << "SpectraDialog::setMolecule: No spectra available!";
@@ -1182,10 +1159,8 @@ namespace Avogadro {
   {
     if (m_spectra == "Infrared")
       return m_spectra_ir;
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     else if (m_spectra == "NearInfrared")
         return m_spectra_nearir;
-#endif
     else if (m_spectra == "NMR")
       return m_spectra_nmr;
     else if (m_spectra == "DOS")
@@ -1198,12 +1173,10 @@ namespace Avogadro {
         return m_spectra_energy;
     else if (m_spectra == "Raman")
         return m_spectra_raman;
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     else if (m_spectra == "Absorption")
         return m_spectra_absorption;
     else if (m_spectra == "Emission")
         return m_spectra_emission;
-#endif
 
     return NULL;
   }

--- a/libavogadro/src/extensions/spectra/spectradialog.cpp
+++ b/libavogadro/src/extensions/spectra/spectradialog.cpp
@@ -81,8 +81,10 @@ namespace Avogadro {
     m_spectra_cd = new CDSpectra(this);
     m_spectra_raman = new RamanSpectra(this);
     m_spectra_energy = new EnergySpectra(this);
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     m_spectra_absorption = new OrcaAbsSpectra(this);
     m_spectra_emission = new OrcaEmissionSpectra(this);
+#endif
     // Initialize vars
     m_schemes = new QList<QHash<QString, QVariant> >;
 
@@ -173,8 +175,10 @@ namespace Avogadro {
     delete m_spectra_cd;
     delete m_spectra_raman;
     delete m_spectra_energy;
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     delete m_spectra_emission;
     delete m_spectra_absorption;
+#endif
   }
 
   void SpectraDialog::setMolecule(Molecule *molecule)
@@ -194,8 +198,10 @@ namespace Avogadro {
     m_spectra_cd->clear();
     m_spectra_raman->clear();
     m_spectra_energy->clear();
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     m_spectra_absorption->clear();
     m_spectra_emission->clear();
+#endif
     updatePlot();
 
     // set the filename in the image export widget
@@ -274,6 +280,7 @@ namespace Avogadro {
       ui.tab_widget->addTab(m_spectra_raman->getTabWidget(), tr("&Raman Settings"));
     }
 
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     // Check for ORCA absorption data
     bool hasAbsorption = m_spectra_absorption->checkForData(m_molecule);
     if (hasAbsorption) {
@@ -286,6 +293,10 @@ namespace Avogadro {
       ui.combo_spectra->addItem(tr("Emission", "Emission spectrum"));
       ui.tab_widget->addTab(m_spectra_emission->getTabWidget(), tr("&Emission Settings"));
     }
+#else
+    bool hasAbsorption = false;
+    bool hasEmission = false;
+#endif
     // Change this when other spectra are added!!
     if (!hasIR && !hasNearIR && !hasNMR && !hasDOS && !hasUV && !hasCD && !hasRaman && !hasEnergy && !hasAbsorption && !hasEmission) { // Actions if there are no spectra loaded
       qWarning() << "SpectraDialog::setMolecule: No spectra available!";
@@ -1187,10 +1198,12 @@ namespace Avogadro {
         return m_spectra_energy;
     else if (m_spectra == "Raman")
         return m_spectra_raman;
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     else if (m_spectra == "Absorption")
         return m_spectra_absorption;
     else if (m_spectra == "Emission")
         return m_spectra_emission;
+#endif
 
     return NULL;
   }

--- a/libavogadro/src/extensions/spectra/spectradialog.h
+++ b/libavogadro/src/extensions/spectra/spectradialog.h
@@ -45,6 +45,7 @@ namespace Avogadro {
 
   class SpectraType;
   class IRSpectra;
+  class NearIRSpectra;
   class NMRSpectra;
   class DOSSpectra;
   class UVSpectra;
@@ -104,6 +105,7 @@ namespace Avogadro {
     Ui::SpectraDialog ui;
 
     IRSpectra *m_spectra_ir;
+    NearIRSpectra *m_spectra_nearir;
     NMRSpectra *m_spectra_nmr;
     DOSSpectra *m_spectra_dos;
     UVSpectra *m_spectra_uv;

--- a/libavogadro/src/extensions/spectra/spectradialog.h
+++ b/libavogadro/src/extensions/spectra/spectradialog.h
@@ -45,7 +45,9 @@ namespace Avogadro {
 
   class SpectraType;
   class IRSpectra;
+#ifdef HAVE_OB_ORCA_SPEC_DATA
   class NearIRSpectra;
+#endif
   class NMRSpectra;
   class DOSSpectra;
   class UVSpectra;
@@ -105,7 +107,9 @@ namespace Avogadro {
     Ui::SpectraDialog ui;
 
     IRSpectra *m_spectra_ir;
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     NearIRSpectra *m_spectra_nearir;
+#endif
     NMRSpectra *m_spectra_nmr;
     DOSSpectra *m_spectra_dos;
     UVSpectra *m_spectra_uv;

--- a/libavogadro/src/extensions/spectra/spectradialog.h
+++ b/libavogadro/src/extensions/spectra/spectradialog.h
@@ -54,8 +54,10 @@ namespace Avogadro {
   class CDSpectra;
   class RamanSpectra;
   class EnergySpectra;
+#ifdef HAVE_OB_ORCA_SPEC_DATA
   class OrcaEmissionSpectra;
   class OrcaAbsSpectra;
+#endif
 
   class SpectraDialog : public QDialog
   {
@@ -116,8 +118,10 @@ namespace Avogadro {
     CDSpectra *m_spectra_cd;
     RamanSpectra *m_spectra_raman;
     EnergySpectra *m_spectra_energy;
+#ifdef HAVE_OB_ORCA_SPEC_DATA
     OrcaEmissionSpectra *m_spectra_emission;
     OrcaAbsSpectra *m_spectra_absorption;
+#endif
     Molecule *m_molecule;
     int m_scheme;
     QList<QHash<QString, QVariant> > *m_schemes;

--- a/libavogadro/src/extensions/spectra/spectradialog.h
+++ b/libavogadro/src/extensions/spectra/spectradialog.h
@@ -45,19 +45,15 @@ namespace Avogadro {
 
   class SpectraType;
   class IRSpectra;
-#ifdef HAVE_OB_ORCA_SPEC_DATA
   class NearIRSpectra;
-#endif
   class NMRSpectra;
   class DOSSpectra;
   class UVSpectra;
   class CDSpectra;
   class RamanSpectra;
   class EnergySpectra;
-#ifdef HAVE_OB_ORCA_SPEC_DATA
   class OrcaEmissionSpectra;
   class OrcaAbsSpectra;
-#endif
 
   class SpectraDialog : public QDialog
   {
@@ -109,19 +105,15 @@ namespace Avogadro {
     Ui::SpectraDialog ui;
 
     IRSpectra *m_spectra_ir;
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     NearIRSpectra *m_spectra_nearir;
-#endif
     NMRSpectra *m_spectra_nmr;
     DOSSpectra *m_spectra_dos;
     UVSpectra *m_spectra_uv;
     CDSpectra *m_spectra_cd;
     RamanSpectra *m_spectra_raman;
     EnergySpectra *m_spectra_energy;
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     OrcaEmissionSpectra *m_spectra_emission;
     OrcaAbsSpectra *m_spectra_absorption;
-#endif
     Molecule *m_molecule;
     int m_scheme;
     QList<QHash<QString, QVariant> > *m_schemes;

--- a/libavogadro/src/extensions/surfaces/orbitalextension.cpp
+++ b/libavogadro/src/extensions/surfaces/orbitalextension.cpp
@@ -872,5 +872,4 @@ namespace Avogadro
 
 } // End namespace Avogadro
 
-Q_EXPORT_PLUGIN2(orbitalextension, Avogadro::OrbitalExtensionFactory)
 

--- a/libavogadro/src/extensions/surfaces/orbitalextension.cpp
+++ b/libavogadro/src/extensions/surfaces/orbitalextension.cpp
@@ -872,3 +872,5 @@ namespace Avogadro
 
 } // End namespace Avogadro
 
+Q_EXPORT_PLUGIN2(orbitalextension, Avogadro::OrbitalExtensionFactory)
+

--- a/libavogadro/src/molecule.cpp
+++ b/libavogadro/src/molecule.cpp
@@ -72,10 +72,8 @@ namespace Avogadro{
                          obmol(0), obunitcell(0),
                          obvibdata(0), obdosdata(0),
                          obelectronictransitiondata(0),
-                         obconformerdata(0)
-#ifdef HAVE_OB_ORCA_SPEC_DATA
-                         ,oborcaspecdata(0), oborcanearirdata(0)
-#endif
+                         obconformerdata(0),
+                         oborcaspecdata(0), oborcanearirdata(0)
     {}
     // These are logically cached variables and thus are marked as mutable.
     // Const objects should be logically constant (and not mutable)
@@ -115,10 +113,8 @@ namespace Avogadro{
       OpenBabel::OBElectronicTransitionData *
                                     obelectronictransitiondata;
       OpenBabel::OBConformerData *  obconformerdata;
-#ifdef HAVE_OB_ORCA_SPEC_DATA
       OpenBabel::OBOrcaSpecData *   oborcaspecdata;
       OpenBabel::OBOrcaNearIRData * oborcanearirdata;
-#endif
 
   };
 
@@ -1324,7 +1320,6 @@ namespace Avogadro{
     if (d->obconformerdata != NULL) {
       obmol.SetData(d->obconformerdata->Clone(&obmol));
     }
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     // Copy Orca spectra data, if needed
     if (d->oborcaspecdata != NULL) {
       obmol.SetData(d->oborcaspecdata->Clone(&obmol));
@@ -1333,7 +1328,6 @@ namespace Avogadro{
     if (d->oborcanearirdata != NULL) {
       obmol.SetData(d->oborcanearirdata->Clone(&obmol));
     }
-#endif
 
     return obmol;
   }
@@ -1510,7 +1504,6 @@ namespace Avogadro{
       d->obelectronictransitiondata = etd;
     }
 
-#ifdef HAVE_OB_ORCA_SPEC_DATA
     // Copy Orca spectra data
     qDebug() << "has Orca spectra data  = " << obmol->HasData(OpenBabel::OBGenericDataType::CustomData0) << endl;
     if (obmol->HasData(OpenBabel::OBGenericDataType::CustomData0)) {
@@ -1525,7 +1518,6 @@ namespace Avogadro{
         static_cast<OpenBabel::OBOrcaNearIRData*>(obmol->GetData(OpenBabel::OBGenericDataType::CustomData1));
       d->oborcanearirdata = nearIRData;
     }
-#endif
 
     // Copy orbital energies, symbols, and occupations to dynamic properties (as QList<>)
     qDebug() << "has data  = " << obmol->HasData(OpenBabel::OBGenericDataType::ElectronicData) << endl;

--- a/libavogadro/src/molecule.cpp
+++ b/libavogadro/src/molecule.cpp
@@ -50,7 +50,6 @@
 #include <openbabel/griddata.h>
 #include <openbabel/grid.h>
 #include <openbabel/generic.h>
-#include <openbabel/oborcadata.h>
 #include <openbabel/obfunctions.h>
 #include <openbabel/forcefield.h>
 #include <openbabel/obiter.h>

--- a/libavogadro/src/molecule.cpp
+++ b/libavogadro/src/molecule.cpp
@@ -73,6 +73,9 @@ namespace Avogadro{
                          obvibdata(0), obdosdata(0),
                          obelectronictransitiondata(0),
                          obconformerdata(0)
+#ifdef HAVE_OB_ORCA_SPEC_DATA
+                         ,oborcaspecdata(0), oborcanearirdata(0)
+#endif
     {}
     // These are logically cached variables and thus are marked as mutable.
     // Const objects should be logically constant (and not mutable)
@@ -112,6 +115,10 @@ namespace Avogadro{
       OpenBabel::OBElectronicTransitionData *
                                     obelectronictransitiondata;
       OpenBabel::OBConformerData *  obconformerdata;
+#ifdef HAVE_OB_ORCA_SPEC_DATA
+      OpenBabel::OBOrcaSpecData *   oborcaspecdata;
+      OpenBabel::OBOrcaNearIRData * oborcanearirdata;
+#endif
 
   };
 
@@ -1317,6 +1324,16 @@ namespace Avogadro{
     if (d->obconformerdata != NULL) {
       obmol.SetData(d->obconformerdata->Clone(&obmol));
     }
+#ifdef HAVE_OB_ORCA_SPEC_DATA
+    // Copy Orca spectra data, if needed
+    if (d->oborcaspecdata != NULL) {
+      obmol.SetData(d->oborcaspecdata->Clone(&obmol));
+    }
+    // Copy Orca NearIR spectra data, if needed
+    if (d->oborcanearirdata != NULL) {
+      obmol.SetData(d->oborcanearirdata->Clone(&obmol));
+    }
+#endif
 
     return obmol;
   }
@@ -1493,7 +1510,22 @@ namespace Avogadro{
       d->obelectronictransitiondata = etd;
     }
 
-    // Orca spectra data not supported with Open Babel 3
+#ifdef HAVE_OB_ORCA_SPEC_DATA
+    // Copy Orca spectra data
+    qDebug() << "has Orca spectra data  = " << obmol->HasData(OpenBabel::OBGenericDataType::CustomData0) << endl;
+    if (obmol->HasData(OpenBabel::OBGenericDataType::CustomData0)) {
+      OpenBabel::OBOrcaSpecData *specorca =
+        static_cast<OpenBabel::OBOrcaSpecData*>(obmol->GetData(OpenBabel::OBGenericDataType::CustomData0));
+      d->oborcaspecdata = specorca;
+    }
+    // Copy Orca NearIR spectra data
+    qDebug() << "has NearIR spectra data  = " << obmol->HasData(OpenBabel::OBGenericDataType::CustomData1) << endl;
+    if (obmol->HasData(OpenBabel::OBGenericDataType::CustomData1)) {
+      OpenBabel::OBOrcaNearIRData *nearIRData =
+        static_cast<OpenBabel::OBOrcaNearIRData*>(obmol->GetData(OpenBabel::OBGenericDataType::CustomData1));
+      d->oborcanearirdata = nearIRData;
+    }
+#endif
 
     // Copy orbital energies, symbols, and occupations to dynamic properties (as QList<>)
     qDebug() << "has data  = " << obmol->HasData(OpenBabel::OBGenericDataType::ElectronicData) << endl;

--- a/libavogadro/src/molecule.cpp
+++ b/libavogadro/src/molecule.cpp
@@ -50,6 +50,7 @@
 #include <openbabel/griddata.h>
 #include <openbabel/grid.h>
 #include <openbabel/generic.h>
+#include <openbabel/oborcadata.h>
 #include <openbabel/obfunctions.h>
 #include <openbabel/forcefield.h>
 #include <openbabel/obiter.h>

--- a/libavogadro/src/molecule.h
+++ b/libavogadro/src/molecule.h
@@ -38,6 +38,14 @@ namespace OpenBabel {
   class OBBond;
   class OBMol;
   class OBUnitCell;
+  class OBConformerData;
+#ifdef HAVE_OB_ORCA_SPEC_DATA
+  class OBOrcaSpecData;
+  class OBElectronicTransitionData;
+  class OBOrcaNearIRData;
+#endif
+  class OBVibrationData;
+  class OBDOSData;
 }
 
 namespace Avogadro {

--- a/libavogadro/src/molecule.h
+++ b/libavogadro/src/molecule.h
@@ -39,11 +39,9 @@ namespace OpenBabel {
   class OBMol;
   class OBUnitCell;
   class OBConformerData;
-#ifdef HAVE_OB_ORCA_SPEC_DATA
   class OBOrcaSpecData;
   class OBElectronicTransitionData;
   class OBOrcaNearIRData;
-#endif
   class OBVibrationData;
   class OBDOSData;
 }


### PR DESCRIPTION
## Summary
- add a CMake check for OpenBabel ORCA spectral classes
- compile ORCA spectra features only when the classes exist

## Testing
- `cmake ..`
- `cmake --build . -- -j1` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68641b61a4c88333834ba86c0badbbf4