### PR TITLE
Enable drag-and-drop on Windows

### DIFF
--- a/avogadro/src/mainwindow.cpp
+++ b/avogadro/src/mainwindow.cpp
@@ -379,6 +379,8 @@ protected:
 
     setAttribute( Qt::WA_DeleteOnClose );
     setAcceptDrops(true);
+    ui.centralWidget->setAcceptDrops(true);
+    d->centralTab->setAcceptDrops(true);
 
     // add our bottom flat tabs
     d->bottomFlat = new FlatTabWidget(this);


### PR DESCRIPTION
## Summary
- enable drop events on `centralWidget` and tab widget

## Testing
- `cmake ..`
- `cmake --build . --target avogadro-app -j2`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6863fc368fbc83339a135630c169324a