### PR TITLE
Fix installer run to launch Avogadro without admin rights

### DIFF
--- a/scripts/installer/setup.nsi
+++ b/scripts/installer/setup.nsi
@@ -189,6 +189,7 @@ ${Index_RemoveFilesAndSubDirs}-done:
 !define MUI_FINISHPAGE_RUN "${PRODUCT_EXE}"
 !define MUI_FINISHPAGE_TEXT "$(FinishPageMessage)"
 !define MUI_FINISHPAGE_RUN_TEXT "$(FinishPageRun)"
+!define MUI_FINISHPAGE_RUN_FUNCTION LaunchAvogadroAsUser
 !insertmacro MUI_PAGE_FINISH
 
 # The uninstaller
@@ -369,4 +370,10 @@ Function un.onUninstSuccess
   HideWindow
   MessageBox MB_ICONINFORMATION|MB_OK "$(UnRemoveSuccessLabel)"
 
+FunctionEnd
+
+# Launch Avogadro with normal user privileges when the installer finishes.
+Function LaunchAvogadroAsUser
+  ; Use explorer.exe to inherit the current user's privileges
+  Exec '"$WINDIR\explorer.exe" "$INSTDIR\bin\Avogadro.exe"'
 FunctionEnd


### PR DESCRIPTION
## Summary
- ensure Avogadro is started with normal user privileges when run from the installer

## Testing
- `cmake -S . -B build -DBUILD_TESTING=OFF` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6864534054288333a41cca9d5910224b