### PR TITLE
Add InChI paste feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ plugin architecture.
 * **Intuitive**: Built to work easily for students and advanced researchers both.
 * **Fast**: Supports multi-threaded rendering and computation.
 * **Extensible:** Plugin architecture for developers, including rendering, interactive tools, commands, and Python scripts.
-* **Flexible**: Features include Open Babel import of chemical files, input generation for multiple computational chemistry packages, crystallography, and biomolecules.
+* **Flexible**: Features include Open Babel import of chemical files, building molecules from SMILES or InChI strings, input generation for multiple computational chemistry packages, crystallography, and biomolecules.
 
 For more information, see <http://avogadro.cc/>
 

--- a/i18n/libavogadro/libavogadro.pot
+++ b/i18n/libavogadro/libavogadro.pot
@@ -1715,13 +1715,25 @@ msgstr ""
 msgid "SMILES..."
 msgstr ""
 
+#: src/extensions/insertfragmentextension.cpp:74
+msgid "InChI..."
+msgstr ""
+
 #: src/extensions/insertfragmentextension.cpp:121
 #: src/extensions/insertfragmentextension.cpp:166
 msgid "Insert SMILES"
 msgstr ""
 
+#: src/extensions/insertfragmentextension.cpp:186
+msgid "Insert InChI"
+msgstr ""
+
 #: src/extensions/insertfragmentextension.cpp:122
 msgid "Insert SMILES fragment:"
+msgstr ""
+
+#: src/extensions/insertfragmentextension.cpp:187
+msgid "Insert InChI code:"
 msgstr ""
 
 #: src/extensions/insertfragmentextension.cpp:171

--- a/i18n/libavogadro/libavogadro.pot
+++ b/i18n/libavogadro/libavogadro.pot
@@ -1736,6 +1736,10 @@ msgstr ""
 msgid "Insert InChI code:"
 msgstr ""
 
+#: src/extensions/insertfragmentextension.cpp:203
+msgid "Could not build from InChI."
+msgstr ""
+
 #: src/extensions/insertfragmentextension.cpp:171
 #: src/extensions/insertfragmentextension.cpp:310
 #: src/extensions/insertfragmentextension.h:36

--- a/libavogadro/src/extensions/insertfragmentextension.cpp
+++ b/libavogadro/src/extensions/insertfragmentextension.cpp
@@ -184,6 +184,7 @@ namespace Avogadro {
       OBConversion conv;
 
       bool ok, noConnection;
+      bool success = false;
       QList<int> selectedIds;
       QString inchi = QInputDialog::getText((widget),
                                             tr("Insert InChI"),

--- a/libavogadro/src/extensions/insertfragmentextension.h
+++ b/libavogadro/src/extensions/insertfragmentextension.h
@@ -68,6 +68,7 @@ namespace Avogadro {
     InsertFragmentDialog *m_fragmentDialog;
     InsertFragmentDialog *m_crystalDialog;
     QString   m_smilesString;
+    QString   m_inchiString;
     Molecule *m_molecule;
 
     bool     m_justFinished;

--- a/libavogadro/src/extensions/spectra/ir.cpp
+++ b/libavogadro/src/extensions/spectra/ir.cpp
@@ -86,6 +86,7 @@ namespace Avogadro {
     qDebug() << "has IR data " << wavenumbers.size();
 
     // check if there are also data from a nearIR spectrum
+#if OB_VERSION < OB_VERSION_CHECK(3, 0, 0)
     OpenBabel::OBOrcaNearIRData *ond = static_cast<OpenBabel::OBOrcaNearIRData*>(obmol.GetData("OrcaNearIRSpectraData"));
     if (ond) {
         qDebug() << "has also nearIR data " << wavenumbers.size();
@@ -102,6 +103,7 @@ namespace Avogadro {
             }
         }
     }
+#endif
 
     // Case where there are no intensities, set all intensities to an arbitrary value, i.e. 1.0
     if (wavenumbers.size() > 0 && intensities.size() == 0) {

--- a/libavogadro/src/extensions/spectra/ir.cpp
+++ b/libavogadro/src/extensions/spectra/ir.cpp
@@ -87,6 +87,8 @@ namespace Avogadro {
 
     // check if there are also data from a nearIR spectrum
 #if OB_VERSION < OB_VERSION_CHECK(3, 0, 0)
+    // Only compiled when using Open Babel 2.x. This guard doesn't solve
+    // near-IR crashes but keeps the build working with Open Babel 3.
     OpenBabel::OBOrcaNearIRData *ond = static_cast<OpenBabel::OBOrcaNearIRData*>(obmol.GetData("OrcaNearIRSpectraData"));
     if (ond) {
         qDebug() << "has also nearIR data " << wavenumbers.size();

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -72,10 +72,6 @@ bool NearIRSpectra::checkForData(Molecule * mol) {
     // OK, we have valid vibrations, so store them for later
     vector<double> wavenumbers = ond->GetFrequencies();
     vector<double> intensities = ond->GetIntensities();
-#else
-    Q_UNUSED(obmol);
-    return false; // Open Babel 3 removed this data type
-#endif
 
     // Case where there are no intensities, set all intensities to an arbitrary value, i.e. 1.0
     if (wavenumbers.size() > 0 && intensities.size() == 0) {
@@ -117,6 +113,10 @@ bool NearIRSpectra::checkForData(Molecule * mol) {
     }
 
     return true;
+#else
+    Q_UNUSED(obmol);
+    return false; // Open Babel 3 removed this data type
+#endif
 }
 void NearIRSpectra::setupPlot(PlotWidget * plot) {
   plot->setDefaultLimits( 3500.0, 400.0, 0.0, 100.0 );

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -58,10 +58,15 @@ void NearIRSpectra::writeSettings()
 bool NearIRSpectra::checkForData(Molecule * mol) {
     OpenBabel::OBMol obmol = mol->OBMol();
 //    OpenBabel::OBVibrationData *vibrations = static_cast<OpenBabel::OBVibrationData*>(obmol.GetData(OpenBabel::OBGenericDataType::VibrationData));
+#if OB_VERSION < OB_VERSION_CHECK(3, 0, 0)
     OpenBabel::OBOrcaNearIRData *ond = static_cast<OpenBabel::OBOrcaNearIRData*>(obmol.GetData("OrcaNearIRSpectraData"));
 
     if (!ond) return false;
     if (!ond->GetNearIRData()) return false;
+#else
+    Q_UNUSED(obmol);
+    return false; // Open Babel 3 removed this data type
+#endif
 
     // OK, we have valid vibrations, so store them for later
     vector<double> wavenumbers = ond->GetFrequencies();

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -61,18 +61,21 @@ bool NearIRSpectra::checkForData(Molecule * mol) {
 #if OB_VERSION < OB_VERSION_CHECK(3, 0, 0)
     // Only available in Open Babel 2.x. This guard does not fix crashes
     // when reading newer files, but it avoids compilation errors.
-    OpenBabel::OBOrcaNearIRData *ond = static_cast<OpenBabel::OBOrcaNearIRData*>(obmol.GetData("OrcaNearIRSpectraData"));
+    OpenBabel::OBOrcaNearIRData *ond = static_cast<OpenBabel::OBOrcaNearIRData*>(
+        obmol.GetData("OrcaNearIRSpectraData"));
 
-    if (!ond) return false;
-    if (!ond->GetNearIRData()) return false;
-#else
-    Q_UNUSED(obmol);
-    return false; // Open Babel 3 removed this data type
-#endif
+    if (!ond)
+        return false;
+    if (!ond->GetNearIRData())
+        return false;
 
     // OK, we have valid vibrations, so store them for later
     vector<double> wavenumbers = ond->GetFrequencies();
     vector<double> intensities = ond->GetIntensities();
+#else
+    Q_UNUSED(obmol);
+    return false; // Open Babel 3 removed this data type
+#endif
 
     // Case where there are no intensities, set all intensities to an arbitrary value, i.e. 1.0
     if (wavenumbers.size() > 0 && intensities.size() == 0) {

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -59,6 +59,8 @@ bool NearIRSpectra::checkForData(Molecule * mol) {
     OpenBabel::OBMol obmol = mol->OBMol();
 //    OpenBabel::OBVibrationData *vibrations = static_cast<OpenBabel::OBVibrationData*>(obmol.GetData(OpenBabel::OBGenericDataType::VibrationData));
 #if OB_VERSION < OB_VERSION_CHECK(3, 0, 0)
+    // Only available in Open Babel 2.x. This guard does not fix crashes
+    // when reading newer files, but it avoids compilation errors.
     OpenBabel::OBOrcaNearIRData *ond = static_cast<OpenBabel::OBOrcaNearIRData*>(obmol.GetData("OrcaNearIRSpectraData"));
 
     if (!ond) return false;

--- a/libavogadro/src/molecule.cpp
+++ b/libavogadro/src/molecule.cpp
@@ -72,8 +72,10 @@ namespace Avogadro{
                          obmol(0), obunitcell(0),
                          obvibdata(0), obdosdata(0),
                          obelectronictransitiondata(0),
-                         obconformerdata(0),
-                         oborcaspecdata(0), oborcanearirdata(0)
+                         obconformerdata(0)
+#if OB_VERSION < OB_VERSION_CHECK(3, 0, 0)
+                         , oborcaspecdata(0), oborcanearirdata(0)
+#endif
     {}
     // These are logically cached variables and thus are marked as mutable.
     // Const objects should be logically constant (and not mutable)
@@ -113,8 +115,10 @@ namespace Avogadro{
       OpenBabel::OBElectronicTransitionData *
                                     obelectronictransitiondata;
       OpenBabel::OBConformerData *  obconformerdata;
+#if OB_VERSION < OB_VERSION_CHECK(3, 0, 0)
       OpenBabel::OBOrcaSpecData *   oborcaspecdata;
       OpenBabel::OBOrcaNearIRData * oborcanearirdata;
+#endif
 
   };
 
@@ -1320,6 +1324,7 @@ namespace Avogadro{
     if (d->obconformerdata != NULL) {
       obmol.SetData(d->obconformerdata->Clone(&obmol));
     }
+#if OB_VERSION < OB_VERSION_CHECK(3, 0, 0)
     // Copy Orca spectra data, if needed
     if (d->oborcaspecdata != NULL) {
       obmol.SetData(d->oborcaspecdata->Clone(&obmol));
@@ -1328,6 +1333,7 @@ namespace Avogadro{
     if (d->oborcanearirdata != NULL) {
       obmol.SetData(d->oborcanearirdata->Clone(&obmol));
     }
+#endif
 
     return obmol;
   }
@@ -1504,6 +1510,7 @@ namespace Avogadro{
       d->obelectronictransitiondata = etd;
     }
 
+#if OB_VERSION < OB_VERSION_CHECK(3, 0, 0)
     // Copy Orca spectra data
     qDebug() << "has Orca spectra data  = " << obmol->HasData(OpenBabel::OBGenericDataType::CustomData0) << endl;
     if (obmol->HasData(OpenBabel::OBGenericDataType::CustomData0)) {
@@ -1518,6 +1525,7 @@ namespace Avogadro{
         static_cast<OpenBabel::OBOrcaNearIRData*>(obmol->GetData(OpenBabel::OBGenericDataType::CustomData1));
       d->oborcanearirdata = nearIRData;
     }
+#endif
 
     // Copy orbital energies, symbols, and occupations to dynamic properties (as QList<>)
     qDebug() << "has data  = " << obmol->HasData(OpenBabel::OBGenericDataType::ElectronicData) << endl;

--- a/libavogadro/src/molecule.h
+++ b/libavogadro/src/molecule.h
@@ -32,6 +32,7 @@
 #include <QReadWriteLock>
 
 #include <vector>
+#include <openbabel/babelconfig.h>
 
 namespace OpenBabel {
   class OBAtom;
@@ -39,9 +40,13 @@ namespace OpenBabel {
   class OBMol;
   class OBUnitCell;
   class OBConformerData;
+#if OB_VERSION < OB_VERSION_CHECK(3, 0, 0)
   class OBOrcaSpecData;
+#endif
   class OBElectronicTransitionData;
+#if OB_VERSION < OB_VERSION_CHECK(3, 0, 0)
   class OBOrcaNearIRData;
+#endif
   class OBVibrationData;
   class OBDOSData;
 }

--- a/libavogadro/tests/CMakeLists.txt
+++ b/libavogadro/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(tests
   moleculefile
   neighborlist
   addremovehydrogens
+  inchipaste
 )
 if(XTB_FOUND)
   list(APPEND tests xtbopttool xtbphysics)

--- a/libavogadro/tests/inchipastetest.cpp
+++ b/libavogadro/tests/inchipastetest.cpp
@@ -15,6 +15,7 @@ class InChIPasteTest : public QObject
   Q_OBJECT
 private slots:
   void buildFromInChI();
+  void heterocycleInChI();
 };
 
 void InChIPasteTest::buildFromInChI()
@@ -32,6 +33,33 @@ void InChIPasteTest::buildFromInChI()
   mol.addHydrogens();
 
   QCOMPARE(mol.numAtoms(), static_cast<unsigned int>(5));
+}
+
+void InChIPasteTest::heterocycleInChI()
+{
+  struct Case { const char* inchi; unsigned int atoms; } cases[] = {
+    {"InChI=1S/C5H5N/c1-2-4-6-5-3-1/h1-5H", 11}, // Pyridine
+    {"InChI=1S/C4H4O/c1-2-4-5-3-1/h1-4H", 9},    // Furan
+    {"InChI=1S/C4H4S/c1-2-4-5-3-1/h1-4H", 9},    // Thiophene
+    {"InChI=1S/C4H4N2/c1-2-5-4-6-3-1/h1-4H", 10}, // Pyrimidine
+    {"InChI=1S/C8H7N/c1-2-4-8-7(3-1)5-6-9-8/h1-6,9H", 16} // Indole
+  };
+
+  OBConversion conv;
+  QVERIFY(conv.SetInFormat("inchi"));
+  OBBuilder builder;
+
+  for (const auto &c : cases) {
+    OBMol obmol;
+    QVERIFY(conv.ReadString(&obmol, c.inchi));
+    builder.Build(obmol);
+
+    Molecule mol;
+    mol.setOBMol(&obmol);
+    mol.addHydrogens();
+
+    QCOMPARE(mol.numAtoms(), c.atoms);
+  }
 }
 
 QTEST_MAIN(InChIPasteTest)

--- a/libavogadro/tests/inchipastetest.cpp
+++ b/libavogadro/tests/inchipastetest.cpp
@@ -29,6 +29,7 @@ void InChIPasteTest::buildFromInChI()
 
   Molecule mol;
   mol.setOBMol(&obmol);
+  mol.addHydrogens();
 
   QCOMPARE(mol.numAtoms(), static_cast<unsigned int>(5));
 }

--- a/libavogadro/tests/inchipastetest.cpp
+++ b/libavogadro/tests/inchipastetest.cpp
@@ -1,0 +1,37 @@
+#include "config.h"
+#include <QtTest>
+#include <avogadro/molecule.h>
+#include <openbabel/mol.h>
+#include <openbabel/builder.h>
+#include <openbabel/obconversion.h>
+
+using Avogadro::Molecule;
+using OpenBabel::OBMol;
+using OpenBabel::OBBuilder;
+using OpenBabel::OBConversion;
+
+class InChIPasteTest : public QObject
+{
+  Q_OBJECT
+private slots:
+  void buildFromInChI();
+};
+
+void InChIPasteTest::buildFromInChI()
+{
+  OBMol obmol;
+  OBConversion conv;
+  QVERIFY(conv.SetInFormat("inchi"));
+  QVERIFY(conv.ReadString(&obmol, "InChI=1S/CH4/h1H4"));
+
+  OBBuilder builder;
+  builder.Build(obmol);
+
+  Molecule mol;
+  mol.setOBMol(&obmol);
+
+  QCOMPARE(mol.numAtoms(), static_cast<unsigned int>(5));
+}
+
+QTEST_MAIN(InChIPasteTest)
+#include "moc_inchipastetest.cpp"

--- a/libavogadro/tests/inchipastetest.cpp
+++ b/libavogadro/tests/inchipastetest.cpp
@@ -42,7 +42,8 @@ void InChIPasteTest::heterocycleInChI()
     {"InChI=1S/C4H4O/c1-2-4-5-3-1/h1-4H", 9},    // Furan
     {"InChI=1S/C4H4S/c1-2-4-5-3-1/h1-4H", 9},    // Thiophene
     {"InChI=1S/C4H4N2/c1-2-5-4-6-3-1/h1-4H", 10}, // Pyrimidine
-    {"InChI=1S/C8H7N/c1-2-4-8-7(3-1)5-6-9-8/h1-6,9H", 16} // Indole
+    {"InChI=1S/C8H7N/c1-2-4-8-7(3-1)5-6-9-8/h1-6,9H", 16}, // Indole
+    {"InChI=1S/C13H5N5S/c14-6-8-5-9(7-15)12-13(18-19-17-12)11(8)10-3-1-2-4-16-10/h1-5H", 24} // large heterocycle
   };
 
   OBConversion conv;


### PR DESCRIPTION
## Summary
- allow building fragments from InChI strings via the Insert Fragment extension
- remember the last used InChI string in settings
- update translation template
- add an InChI conversion unit test
- allow compiling with Open Babel 3 by guarding Orca-specific classes
- document that InChI strings can be used to build molecules

## Testing
- `cmake ..`
- `make -j2` *(interrupted due to long build time)*

------
https://chatgpt.com/codex/tasks/task_e_6866d74a57508333a12295768ead0ccb