### PR TITLE
Dock periodic table in Draw Tool sidebar

### DIFF
--- a/libavogadro/src/tools/drawtool.h
+++ b/libavogadro/src/tools/drawtool.h
@@ -111,6 +111,8 @@ namespace Avogadro {
       void bondOrderChanged( int index );
       void setBondOrder(int i);
 
+      void toggleDockTable(int state);
+
       void clearKeyPressBuffer();
 
     private:
@@ -146,6 +148,7 @@ namespace Avogadro {
       QList<int> m_elementsIndex;
       QComboBox *m_comboBondOrder;
       QCheckBox *m_addHydrogensCheck;
+      QCheckBox *m_dockTableCheck;
       QPushButton *m_tableButton;
       PeriodicTableView *m_periodicTable;
       QPushButton *m_fragmentButton;


### PR DESCRIPTION
## Summary
- allow `DrawTool` to dock the periodic table via checkbox
- popup window remains available when not docked
- keep table visible when docked and hide when popped up

## Testing
- `apt-get update`
- `apt-get install -y build-essential cmake qtbase5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libeigen3-dev libopenbabel-dev zlib1g-dev libglu1-mesa-dev libglew-dev`
- `cmake -S . -B build`
- `make -C build -j2` *(fails: invalid use of incomplete type OBOrcaSpecData)*

------
https://chatgpt.com/codex/tasks/task_e_6866e0279c4883339b716c0637e6e3c0