### PR TITLE
Update installer to use Avogadro icon

### DIFF
--- a/scripts/installer/setup.nsi
+++ b/scripts/installer/setup.nsi
@@ -159,8 +159,8 @@ ${Index_RemoveFilesAndSubDirs}-done:
 !define MUI_ABORTWARNING
 
 # Icons for the installer program
-!define MUI_ICON "${NSISDIR}\Contrib\Graphics\Icons\modern-install-full.ico"
-!define MUI_UNICON "${NSISDIR}\Contrib\Graphics\Icons\modern-uninstall-full.ico"
+!define MUI_ICON "..\scripts\installer\avogadro.ico"
+!define MUI_UNICON "..\scripts\installer\avogadro.ico"
 
 # Welcome page
 !define MUI_WELCOMEPAGE_TEXT "$(WelcomePageText)"


### PR DESCRIPTION
## Summary
- use the Avogadro icon for the Windows installer

## Testing
- `apt-get update`
- `apt-get install` *(partial logs, build aborted)*


------
https://chatgpt.com/codex/tasks/task_e_68686552c5c483338941653cbfc50650