### PR TITLE
Add DPI awareness to NSIS installer

### DIFF
--- a/scripts/installer/setup.nsi
+++ b/scripts/installer/setup.nsi
@@ -16,6 +16,7 @@ SetCompressor lzma
 
 # set execution level for Windows Vista
 RequestExecutionLevel admin
+ManifestDPIAware true
 
 # general definitions
 # you only need to change this section for new releases


### PR DESCRIPTION
## Summary
- ensure the Windows installer scales correctly on high-DPI systems by adding `ManifestDPIAware true`

## Testing
- `apt-get install` to get build dependencies
- `cmake` configuration of OpenBabel (build aborted due to time)
- `ctest` (failed: build directory missing)

------
https://chatgpt.com/codex/tasks/task_e_686a3974249c8333bc262aff5b569cac