### PR TITLE
Add fragments dock button

### DIFF
--- a/avogadro/src/mainwindow.cpp
+++ b/avogadro/src/mainwindow.cpp
@@ -249,6 +249,7 @@ protected:
     MainWindowPrivate() : molecule( 0 ),
       undoStack( 0 ), toolsLayout( 0 ),
       toolSettingsStacked(0), toolSettingsWidget(0), toolSettingsDock(0),
+      fragmentDock(0),
       currentSelectedEngine(0),
       messagesText( 0 ),
       glWidget(0),
@@ -277,6 +278,7 @@ protected:
     QStackedLayout *toolSettingsStacked;
     QWidget *toolSettingsWidget;
     QDockWidget *toolSettingsDock;
+    DockWidget *fragmentDock;
 
     QStackedLayout *enginesStacked;
     Engine         *currentSelectedEngine; // for settings widget title, etc.
@@ -863,6 +865,19 @@ protected:
     d->toolGroup->removeAllTools();
     d->toolGroup->append(d->pluginManager.tools(this));
 
+    // Ensure the fragments dock is available
+    if (!d->fragmentDock) {
+      foreach(Extension *ext, d->pluginManager.extensions(this)) {
+        if (ext->identifier() == QLatin1String("InsertFragment")) {
+          if (ext->numDockWidgets() > 0)
+            d->fragmentDock = ext->dockWidgets().first();
+          else
+            d->fragmentDock = qobject_cast<DockWidget*>(ext->dockWidget());
+          break;
+        }
+      }
+    }
+
     const QList<Tool *> tools = d->toolGroup->tools();
     int toolCount = tools.size();
 
@@ -913,6 +928,15 @@ protected:
     connect(ui.enginesDock, SIGNAL(visibilityChanged(bool)), displaySettings, SLOT(setChecked(bool)));
     connect(displaySettings, SIGNAL(released()), this, SLOT(toggleEngineSettingsDock()));
     ui.toolBar->addWidget(displaySettings);
+
+    QPushButton* fragmentsButton = new QPushButton(tr("Fragments..."), ui.toolBar);
+    fragmentsButton->setCheckable(true);
+    if (d->fragmentDock)
+      fragmentsButton->setChecked(d->fragmentDock->isVisible());
+    connect(fragmentsButton, SIGNAL(released()), this, SLOT(toggleFragmentDock()));
+    if (d->fragmentDock)
+      connect(d->fragmentDock, SIGNAL(visibilityChanged(bool)), fragmentsButton, SLOT(setChecked(bool)));
+    ui.toolBar->addWidget(fragmentsButton);
 
     // Call GLWidget::setToolGroup which will store a pointer to the navigate tool
     foreach(GLWidget *glWidget, d->glWidgets)
@@ -3474,6 +3498,8 @@ protected:
       // window
       if (extension->numDockWidgets() != 0) {
         QList<DockWidget *> widgets = extension->dockWidgets();
+        if (!d->fragmentDock && extension->identifier() == QLatin1String("InsertFragment"))
+          d->fragmentDock = widgets.first();
         for (QList<DockWidget*>::const_iterator it = widgets.constBegin(),
              it_end = widgets.constEnd(); it != it_end; ++it) {
           if (!this->restoreDockWidget(*it)) {
@@ -3488,6 +3514,8 @@ protected:
       else {
         // These are deprecated methods for adding dock widgets.
         QDockWidget *dockWidget = extension->dockWidget();
+        if (!d->fragmentDock && extension->identifier() == QLatin1String("InsertFragment"))
+          d->fragmentDock = qobject_cast<DockWidget*>(dockWidget);
         if(dockWidget) {
           Qt::DockWidgetArea area = Qt::RightDockWidgetArea;
           DockExtension *dock = qobject_cast<DockExtension *>(extension);
@@ -3822,6 +3850,12 @@ protected:
   void MainWindow::toggleEngineSettingsDock()
   {
     ui.enginesDock->setVisible(! ui.enginesDock->isVisible() );
+  }
+
+  void MainWindow::toggleFragmentDock()
+  {
+    if (d->fragmentDock)
+      d->fragmentDock->setVisible(!d->fragmentDock->isVisible());
   }
 
   QStringList MainWindow::pluginSearchDirs()

--- a/avogadro/src/mainwindow.h
+++ b/avogadro/src/mainwindow.h
@@ -327,6 +327,7 @@ namespace Avogadro {
 
       void toggleToolSettingsDock();
       void toggleEngineSettingsDock();
+      void toggleFragmentDock();
 
       void centerStep();
   };

--- a/i18n/avogadro/avogadro.pot
+++ b/i18n/avogadro/avogadro.pot
@@ -135,6 +135,10 @@ msgctxt "Display Settings shortcut"
 msgid "Ctrl+D"
 msgstr ""
 
+#: src/mainwindow.cpp:932
+msgid "Fragments..."
+msgstr ""
+
 #: src/mainwindow.cpp:950 src/mainwindow.cpp:1434
 msgid "Common molecule formats"
 msgstr ""

--- a/libavogadro/src/extensions/insertfragmentdialog.cpp
+++ b/libavogadro/src/extensions/insertfragmentdialog.cpp
@@ -41,7 +41,6 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QDir>
-#include <QCloseEvent>
 #include <QDebug>
 #include <QSortFilterProxyModel>
 #include <QFileSystemModel>
@@ -70,12 +69,13 @@ namespace Avogadro {
 
   };
 
-  InsertFragmentDialog::InsertFragmentDialog(QWidget *parent, QString directory, Qt::WindowFlags) : QDialog(parent)
+  InsertFragmentDialog::InsertFragmentDialog(QWidget *parent,
+                                             QString directory,
+                                             Qt::WindowFlags f)
+    : QWidget(parent, f)
   {
-    // Use a small title bar (Qt::Tool) with no minimize or maximize buttons
-    // much like the Periodic Table widget
-    setWindowFlags(Qt::Dialog | Qt::Tool);
     ui.setupUi(this);
+    setMinimumSize(QSize(300, 300));
 
     d = new InsertFragmentPrivate;
 

--- a/libavogadro/src/extensions/insertfragmentdialog.h
+++ b/libavogadro/src/extensions/insertfragmentdialog.h
@@ -27,18 +27,16 @@
 
 #include <avogadro/global.h>
 
-#include <QDialog>
+#include <QWidget>
 
 #include "ui_insertfragmentdialog.h"
-
-class QCloseEvent;
 
 namespace Avogadro {
 
   class Molecule;
   class InsertFragmentPrivate;
 
-  class InsertFragmentDialog : public QDialog
+  class InsertFragmentDialog : public QWidget
   {
     Q_OBJECT
 

--- a/libavogadro/src/extensions/insertfragmentdialog.ui
+++ b/libavogadro/src/extensions/insertfragmentdialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>InsertFragmentDialog</class>
- <widget class="QDialog" name="InsertFragmentDialog">
+ <widget class="QWidget" name="InsertFragmentDialog">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/libavogadro/src/extensions/insertfragmentextension.h
+++ b/libavogadro/src/extensions/insertfragmentextension.h
@@ -23,6 +23,7 @@
 #define INSERTFRAGMENTEXTENSION_H
 
 #include <avogadro/extension.h>
+#include <avogadro/dockwidget.h>
 #include <QAction>
 
 #include "insertfragmentdialog.h"
@@ -65,6 +66,7 @@ namespace Avogadro {
 
     QList<QAction *> m_actions;
     GLWidget* m_widget;
+    DockWidget *m_fragmentDock;
     InsertFragmentDialog *m_fragmentDialog;
     InsertFragmentDialog *m_crystalDialog;
     QString   m_smilesString;


### PR DESCRIPTION
## Summary
- embed a new "Fragments..." button next to display settings in the toolbar
- manage fragment dock pointer in MainWindow to toggle visibility
- fix cast when initializing the fragment dock

## Testing
- `sudo apt-get update`
- `sudo xargs -a .github/apt-packages.txt apt-get install -y`
- ❌ `cmake --build "$src/build" --target install -j$(nproc)` (interrupted)
- ❌ `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON` (OpenBabel not found)
- ❌ `cmake --build build -- -j$(nproc)` (no Makefile generated)
- ❌ `ctest --test-dir build --output-on-failure` (no tests were found)


------
https://chatgpt.com/codex/tasks/task_e_68698ff8d48c8333aa7227cceb835d5c