### PR TITLE
Fix fragment dock cast

### DIFF
--- a/avogadro/src/mainwindow.cpp
+++ b/avogadro/src/mainwindow.cpp
@@ -870,9 +870,9 @@ protected:
       foreach(Extension *ext, d->pluginManager.extensions(this)) {
         if (ext->identifier() == QLatin1String("InsertFragment")) {
           if (ext->numDockWidgets() > 0)
-            d->fragmentDock = ext->dockWidgets().first();
+            d->fragmentDock = qobject_cast<DockWidget*>(ext->dockWidgets().first());
           else
-            d->fragmentDock = ext->dockWidget();
+            d->fragmentDock = qobject_cast<DockWidget*>(ext->dockWidget());
           break;
         }
       }


### PR DESCRIPTION
## Summary
- fix casting from `QDockWidget*` to `Avogadro::DockWidget*` in `mainwindow.cpp`

## Testing
- `apt-get install ...` *(fails: environment timed out while building OpenBabel)*

------
https://chatgpt.com/codex/tasks/task_e_686b8593692c8333b754eed631796662