### PR TITLE
Improve ChemDraw clipboard handling

### DIFF
--- a/libavogadro/tests/CMakeLists.txt
+++ b/libavogadro/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(tests
   moleculefile
   neighborlist
   addremovehydrogens
+  cdxformat
 )
 if(XTB_FOUND)
   list(APPEND tests xtbopttool xtbphysics)
@@ -50,6 +51,10 @@ foreach (test ${tests})
   QT4_WRAP_CPP(test_MOC_SRCS ${test_MOC_CPPS})
   ADD_CUSTOM_TARGET(${test}testmoc ALL DEPENDS ${test_MOC_SRCS})
   add_executable(${test}test ${test_SRCS})
+  if(test STREQUAL "cdxformat")
+    set(plugin_dir "${OPENBABEL3_LIBRARY_DIRS}/openbabel/${OPENBABEL3_VERSION}")
+    target_compile_definitions(${test}test PRIVATE BABEL_LIBDIR="${plugin_dir}")
+  endif()
   add_dependencies(${test}test ${test}testmoc)
   target_link_libraries(${test}test
     ${OPENBABEL2_LIBRARIES}
@@ -57,7 +62,11 @@ foreach (test ${tests})
     ${QT_QTTEST_LIBRARY}
     avogadro)
   add_test(${test}Test ${CMAKE_BINARY_DIR}/bin/${test}test)
-  set_tests_properties(${test}Test PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+  set(test_env "QT_QPA_PLATFORM=offscreen")
+  if(test STREQUAL "cdxformat")
+    set(test_env "BABEL_LIBDIR=${plugin_dir};${test_env}")
+  endif()
+  set_tests_properties(${test}Test PROPERTIES ENVIRONMENT "${test_env}")
   set_property(SOURCE ${test_SRCS} PROPERTY LABELS avogadro)
   set_property(TARGET ${test}test PROPERTY LABELS avogadro)
   set_property(TEST ${test}Test PROPERTY LABELS avogadro)

--- a/libavogadro/tests/cdxformattest.cpp
+++ b/libavogadro/tests/cdxformattest.cpp
@@ -1,0 +1,86 @@
+#include "config.h"
+#include <QtTest>
+#include <openbabel/obconversion.h>
+#include <openbabel/format.h>
+#include <openbabel/mol.h>
+#include <openbabel/plugin.h>
+#include <QTemporaryFile>
+#include <QDir>
+
+using OpenBabel::OBConversion;
+using OpenBabel::OBFormat;
+using OpenBabel::OBMol;
+using OpenBabel::OBPlugin;
+
+class CdxFormatTest : public QObject
+{
+  Q_OBJECT
+private slots:
+  void readCdx();
+};
+
+void CdxFormatTest::readCdx()
+{
+  // Binary ChemDraw sample (ethanol) encoded as base64 so no external file
+  const char *b64 =
+      "VmpDRDAxMDAEAwIBAAAAAAAAAAAAAACAAAAAAAMAFQAAAENoZW1EcmF3IDE3LjEuMC4xMDUIAA0A"
+      "AABldGhhbm9sLmNkeAQCEAAy7EIA9YjuAACAVgBC3i0BAQkIAABAFwAAAAYAAgkIAABAiAEAQCQC"
+      "DQgBAAEIBwEAAToEAQABOwQBAABFBAEAATwEAQAASgQBAAAMBgEAAQ8GAQABDQYBAABCBAEAAEME"
+      "AQAARAQBAAAKCAgAAwBgAMgAAwALCAgABAAAAPAAAwAJCAQAM7MCAAgIBAAAAAIABwgEAAAAAQAG"
+      "CAQAAAAEAAUIBAAAAB4ABAgCAHgAAwgEAAAAeAAjCAEABQwIAQAAKAgBAAEpCAEAASoIAQABMggB"
+      "AAArCAEAKCwIAQAKLQgBAAEuCAEAAAIIEAAAACQAAAAkAAAAJAAAACQAAQMCAAAAAgMCAAEAAAMy"
+      "AAgA////////AAAAAAAA//8AAAAA/////wAAAAD//wAAAAD/////AAAAAP////8AAP//AAEkAAAA"
+      "AgADAOQEBQBBcmlhbAQA5AQPAFRpbWVzIE5ldyBSb21hbgAIeAAAAwAAAlgCWAAAAAAazBLF/7L/"
+      "shsaExMDZwV7A+AAAgAAAlgCWAAAAAAazBLFAAEAAABkAAAAAQABAQEAAgABJw8AAQABAAAAAAAA"
+      "AAAAAAAAAAIAGQGQAAAAAABgAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAC0CwIAAAC1CxQAAABD"
+      "aGVtaWNhbCBGb3JtdWxhOiC2Cw4AAABFeGFjdCBNYXNzOiC3CxQAAABNb2xlY3VsYXIgV2VpZ2h0"
+      "OiC4CwcAAABtL3o6ILkLFgAAAEVsZW1lbnRhbCBBbmFseXNpczogugsRAAAAQm9pbGluZyBQb2lu"
+      "dDoguwsRAAAATWVsdGluZyBQb2ludDogvAsRAAAAQ3JpdGljYWwgVGVtcDogvQsRAAAAQ3JpdGlj"
+      "YWwgUHJlczogvgsQAAAAQ3JpdGljYWwgVm9sOiC/CxAAAABHaWJicyBFbmVyZ3k6IMALCQAAAExv"
+      "ZyBQOiDBCwYAAABNUjogwgsPAAAASGVucnkncyBMYXc6IMMLEAAAAEhlYXQgb2YgRm9ybTogxAsI"
+      "AAAAdFBTQTogxQsJAAAAQ0xvZ1A6IMYLBwAAAENNUjogxwsIAAAATG9nUzogyAsHAAAAcEthOiDJ"
+      "CwIAAADKCwIAAAALDAIAAQAKDAEAAAkMAQAADAwFAAAAKCMpAYBCAAAABAIQAAAAAAAAAAAAhesB"
+      "A+tRCwIWCAQAAAAkABgIBAAAACQAGQgAABAIAgABAA8IAgABAAOAPAAAAAQCEAAy7EIA9YjuAACA"
+      "VgBC3i0BCgACADsABIA7AAAAAAIIAACAUgD1yO4ACgACADoANwQBAAEAAASAPQAAAAACCAAAgEMA"
+      "CMQIAQoAAgA8ADcEAQABAAAEgD8AAAAAAggAAIBSABy/IgEKAAIAPgACBAIACAArBAIAAQBIBAAA"
+      "NwQBAAEGgAAAAAAAAggAZmZWALXYHgEEAhAAEfFNALXYHgEAgFYAQt4tASMIAQAAAgcCAAAABQcB"
+      "AAEABw4AAQAAAAMAYADIAAAAT0gAAAAABYA+AAAACgACAD0ABAYEADsAAAAFBgQAPQAAAAoGAQAB"
+      "AAAFgEAAAAAKAAIAPwAEBgQAPQAAAAUGBAA/AAAACgYBAAEAAAAAAAAAAAAA";
+
+  QByteArray data = QByteArray::fromBase64(b64);
+  if (qEnvironmentVariableIsEmpty("BABEL_LIBDIR")) {
+    const char *dirs[] = {
+#ifdef BABEL_LIBDIR
+      BABEL_LIBDIR,
+#endif
+      "/usr/lib/openbabel/3.1.1",
+      "/usr/lib/openbabel/3",
+      "/usr/local/lib/openbabel/3.1.1",
+      "/usr/local/lib/openbabel/3",
+      "/usr/lib/x86_64-linux-gnu/openbabel/3.1.1",
+      "/usr/lib/x86_64-linux-gnu/openbabel/3",
+      nullptr};
+    for (int i = 0; dirs[i]; ++i) {
+      if (QDir(dirs[i]).exists()) {
+        qputenv("BABEL_LIBDIR", dirs[i]);
+        break;
+      }
+    }
+    qInfo() << "Using BABEL_LIBDIR=" << qgetenv("BABEL_LIBDIR");
+  }
+  OBPlugin::LoadAllPlugins();
+  OBConversion conv;
+  OBFormat* fmt = conv.FindFormat("cdx");
+  QVERIFY(fmt != nullptr);
+  conv.SetInFormat(fmt);
+  QTemporaryFile tmp;
+  QVERIFY(tmp.open());
+  tmp.write(data);
+  tmp.flush();
+  OBMol mol;
+  QVERIFY(conv.ReadFile(&mol, tmp.fileName().toLatin1().constData()));
+  QVERIFY(mol.NumAtoms() >= 0);
+}
+
+QTEST_MAIN(CdxFormatTest)
+#include "moc_cdxformattest.cpp"


### PR DESCRIPTION
## Summary
- include Qt and Open Babel utilities for CDX clipboard unit test
- set BABEL_LIBDIR if unset before loading plugins
- add plugin directory definition for the test in CMake
- expand fallback paths to include `/usr/lib/x86_64-linux-gnu/openbabel/3`
- search additional paths in the CDX test for Open Babel plugins

## Testing
- `cmake --build build --target cdxformattest -- -j$(nproc)` *(failed: invalid OpenBabel headers)*
- `ctest --test-dir build -R cdxformatTest --output-on-failure` *(failed: executable missing due to build failure)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686b9f70bba483339f437ec63f0326a7