### PR TITLE
Add inertia models for hair animation

### DIFF
--- a/libavogadro/src/engines/hairengine.cpp
+++ b/libavogadro/src/engines/hairengine.cpp
@@ -57,7 +57,16 @@ public:
 HairEngine::HairEngine(QObject *parent) : Engine(parent),
   m_settingsWidget(0), m_length(0.5), m_count(10), m_hasPrevModelView(false)
 {
+  m_settings.model = VectorEMA;
+  m_settings.alpha = 0.2;
+  m_settings.lagFactor = 1.0;
+  m_settings.naturalFreq = 15.0;
+  m_settings.nodesPerStrand = 5;
+  m_settings.stiffness = 0.7;
+  m_settings.drag = 0.03;
+  m_settings.constraintIters = 3;
   m_timer.start();
+  m_frameTimer.start();
 }
 
 HairEngine::~HairEngine()
@@ -73,6 +82,7 @@ Engine *HairEngine::clone() const
   engine->setEnabled(isEnabled());
   engine->m_length = m_length;
   engine->m_count = m_count;
+  engine->m_settings = m_settings;
   engine->m_prevModelView = m_prevModelView;
   engine->m_hasPrevModelView = m_hasPrevModelView;
   return engine;
@@ -80,6 +90,10 @@ Engine *HairEngine::clone() const
 
 bool HairEngine::renderOpaque(PainterDevice *pd)
 {
+  double dt = m_frameTimer.restart() / 1000.0;
+  if (dt <= 1e-6)
+    dt = 1.0 / 60.0;
+
   Eigen::Projective3d curModelView = pd->camera()->modelview();
   if (!m_hasPrevModelView) {
     m_prevModelView = curModelView;
@@ -89,10 +103,12 @@ bool HairEngine::renderOpaque(PainterDevice *pd)
   struct Context {
     Vector3d origin;
     double baseRadius;
-    Vector3d movement;
-    double amp;
+    Vector3d velocity;
+    Vector3d acceleration;
     unsigned int id;
     Color3f color;
+    std::vector<SpringState>* springs;
+    std::vector<Strand>*  mass;
   };
 
   QList<Atom *> atomList = atoms();
@@ -108,24 +124,68 @@ bool HairEngine::renderOpaque(PainterDevice *pd)
     double baseRadius = pd->radius(atom);
 
     Vector3d prev = m_prevPos.value(atom->id(), origin);
-    Vector3d movement = origin - prev;
+    Vector3d vel = (origin - prev) / dt;
+    Vector3d prevVel = m_prevVel.value(atom->id(), Vector3d::Zero());
+    Vector3d acc = (vel - prevVel) / dt;
     m_prevPos[atom->id()] = origin;
-
-    double prevAmp = m_motionAmp.value(atom->id(), 0.0);
-    double newAmp = std::min(movement.norm() * 20.0, 1.0);
-    double smoothAmp = prevAmp * 0.95 + newAmp * 0.05;
-    m_motionAmp[atom->id()] = smoothAmp;
+    m_prevVel[atom->id()] = vel;
 
     Eigen::Vector3d curCam = (pd->camera()->modelview() * origin.homogeneous()).head<3>();
     Eigen::Vector3d prevCam = (m_prevModelView * origin.homogeneous()).head<3>();
     Eigen::Vector3d camDelta = curCam - prevCam;
     camDelta = pd->camera()->modelview().linear().inverse() * camDelta;
-    movement += camDelta;
+    vel += camDelta / dt;
 
     map->setFromPrimitive(atom);
     Color3f col(map->red(), map->green(), map->blue());
 
-    ctxs.push_back({origin, baseRadius, movement, smoothAmp, atom->id(), col});
+    std::vector<SpringState>* sp = nullptr;
+    std::vector<Strand>* ms = nullptr;
+    if (m_settings.model == SpringLag) {
+      sp = &m_springStrands[atom->id()];
+      if (sp->size() != static_cast<size_t>(m_count)) {
+        sp->clear();
+        sp->resize(m_count);
+        for (int j = 0; j < m_count; ++j) {
+          QRandomGenerator gen(static_cast<quint32>(atom->id() * 100 + j));
+          double theta = gen.generateDouble() * M_PI * 2.0;
+          double phi = std::acos(2.0 * gen.generateDouble() - 1.0);
+          Vector3d d(std::sin(phi) * std::cos(theta),
+                     std::sin(phi) * std::sin(theta),
+                     std::cos(phi));
+          (*sp)[j].baseDir = d;
+          (*sp)[j].dir.setZero();
+          (*sp)[j].omega.setZero();
+        }
+      }
+    } else if (m_settings.model == MassSpring) {
+      ms = &m_massStrands[atom->id()];
+      size_t nodeCount = static_cast<size_t>(m_settings.nodesPerStrand - 1);
+      if (ms->size() != static_cast<size_t>(m_count) ||
+          (ms->size() && ms->front().nodes.size() != nodeCount)) {
+        ms->clear();
+        ms->resize(m_count);
+        double rest = m_length / (m_settings.nodesPerStrand - 1);
+        for (int j = 0; j < m_count; ++j) {
+          QRandomGenerator gen(static_cast<quint32>(atom->id() * 100 + j));
+          double theta = gen.generateDouble() * M_PI * 2.0;
+          double phi = std::acos(2.0 * gen.generateDouble() - 1.0);
+          Vector3d d(std::sin(phi) * std::cos(theta),
+                     std::sin(phi) * std::sin(theta),
+                     std::cos(phi));
+          (*ms)[j].baseDir = d;
+          (*ms)[j].nodes.resize(nodeCount);
+          Vector3d pos = origin + d * baseRadius;
+          for (size_t n = 0; n < nodeCount; ++n) {
+            pos += d * rest;
+            (*ms)[j].nodes[n].pos = pos;
+            (*ms)[j].nodes[n].prev = pos;
+          }
+        }
+      }
+    }
+
+    ctxs.push_back({origin, baseRadius, vel, acc, atom->id(), col, sp, ms});
   }
 
   struct Segment { Vector3d a; Vector3d b; Color3f color; };
@@ -142,18 +202,84 @@ bool HairEngine::renderOpaque(PainterDevice *pd)
 
 #pragma omp for nowait schedule(static)
     for (int i = 0; i < ctxSize; ++i) {
-      const Context &c = ctxs[i];
+      Context &c = ctxs[i];
       for (int j = 0; j < m_count; ++j) {
-        QRandomGenerator gen(static_cast<quint32>(c.id * 100 + j));
-        double theta = gen.generateDouble() * M_PI * 2.0;
-        double phi = std::acos(2.0 * gen.generateDouble() - 1.0);
-        Vector3d dir(std::sin(phi) * std::cos(theta),
-                     std::sin(phi) * std::sin(theta),
-                     std::cos(phi));
+        Vector3d dir;
+        if (m_settings.model == VectorEMA) {
+          QRandomGenerator gen(static_cast<quint32>(c.id * 100 + j));
+          double theta = gen.generateDouble() * M_PI * 2.0;
+          double phi = std::acos(2.0 * gen.generateDouble() - 1.0);
+          dir = Vector3d(std::sin(phi) * std::cos(theta),
+                         std::sin(phi) * std::sin(theta),
+                         std::cos(phi));
+        } else if (m_settings.model == SpringLag) {
+          dir = (*(c.springs))[j].baseDir;
+        } else {
+          dir = (*(c.mass))[j].baseDir;
+        }
 
         Vector3d start = c.origin + dir * c.baseRadius;
 
-        Vector3d curlDir = -c.movement;
+        Vector3d curlDir;
+        double amp = 0.0;
+        if (m_settings.model == VectorEMA) {
+          Vector3d prevSmooth = m_smoothVel.value(c.id, Vector3d::Zero());
+          Vector3d smooth = prevSmooth * (1.0 - m_settings.alpha) +
+                           c.velocity * m_settings.alpha;
+          m_smoothVel[c.id] = smooth;
+          curlDir = -smooth;
+          amp = std::min(smooth.norm() * dt * 20.0, 1.0);
+        } else if (m_settings.model == SpringLag) {
+          SpringState &st = (*(c.springs))[j];
+          Vector3d target = -c.velocity;
+          target -= dir * target.dot(dir);
+          if (target.norm() < 1e-3)
+            target = dir.cross(Vector3d::UnitX());
+          if (target.norm() < 1e-3)
+            target = dir.cross(Vector3d::UnitY());
+          target.normalize();
+          double targetAmp = std::min(c.velocity.norm() * dt * 20.0 *
+                                      m_settings.lagFactor, 1.0);
+          target *= targetAmp;
+          Vector3d accel = -2.0 * m_settings.naturalFreq * st.omega -
+                           m_settings.naturalFreq * m_settings.naturalFreq *
+                           (st.dir - target);
+          st.omega += accel * dt;
+          st.dir += st.omega * dt;
+          curlDir = st.dir;
+          amp = curlDir.norm();
+        } else {
+          Strand &st = (*(c.mass))[j];
+          size_t nodeCount = st.nodes.size();
+          double rest = m_length / (m_settings.nodesPerStrand - 1);
+          Vector3d rootAcc = c.acceleration;
+          for (size_t n = 0; n < nodeCount; ++n) {
+            Vector3d vel = st.nodes[n].pos - st.nodes[n].prev;
+            vel *= (1.0 - m_settings.drag);
+            vel += (-rootAcc + Vector3d(0,0,-9.81)) * dt * dt;
+            st.nodes[n].prev = st.nodes[n].pos;
+            st.nodes[n].pos += vel;
+          }
+          for (int it = 0; it < m_settings.constraintIters; ++it) {
+            Vector3d prevP = start;
+            for (size_t n = 0; n < nodeCount; ++n) {
+              Vector3d diff = st.nodes[n].pos - prevP;
+              double len = diff.norm();
+              if (len > 1e-6) {
+                Vector3d corr = diff * (1.0 - rest / len) * m_settings.stiffness;
+                st.nodes[n].pos -= corr;
+              }
+              prevP = st.nodes[n].pos;
+            }
+          }
+          Vector3d prevPoint = start;
+          for (size_t n = 0; n < nodeCount; ++n) {
+            local.push_back({prevPoint, st.nodes[n].pos, c.color});
+            prevPoint = st.nodes[n].pos;
+          }
+          continue;
+        }
+
         curlDir -= dir * curlDir.dot(dir);
         if (curlDir.norm() < 1e-3)
           curlDir = dir.cross(Vector3d::UnitX());
@@ -163,7 +289,7 @@ bool HairEngine::renderOpaque(PainterDevice *pd)
 
         Vector3d prevPoint = start;
         double phase = j + c.id;
-        double baseAmp = m_length * 0.7 * c.amp;
+        double baseAmp = m_length * 0.7 * amp;
         double dynAmp = m_length * 0.3;
         for (int s = 1; s <= segments; ++s) {
           double t = static_cast<double>(s) / segments;
@@ -199,10 +325,34 @@ QWidget *HairEngine::settingsWidget()
             this, SLOT(setLength(double)));
     connect(m_settingsWidget->countSpinBox, SIGNAL(valueChanged(int)),
             this, SLOT(setCount(int)));
+    connect(m_settingsWidget->modelComboBox, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(setInertiaModel(int)));
+    connect(m_settingsWidget->alphaSpinBox, SIGNAL(valueChanged(double)),
+            this, SLOT(setAlpha(double)));
+    connect(m_settingsWidget->lagSpinBox, SIGNAL(valueChanged(double)),
+            this, SLOT(setLagFactor(double)));
+    connect(m_settingsWidget->freqSpinBox, SIGNAL(valueChanged(double)),
+            this, SLOT(setNaturalFreq(double)));
+    connect(m_settingsWidget->nodesSpinBox, SIGNAL(valueChanged(int)),
+            this, SLOT(setNodes(int)));
+    connect(m_settingsWidget->stiffnessSpinBox, SIGNAL(valueChanged(double)),
+            this, SLOT(setStiffness(double)));
+    connect(m_settingsWidget->dragSpinBox, SIGNAL(valueChanged(double)),
+            this, SLOT(setDrag(double)));
+    connect(m_settingsWidget->iterSpinBox, SIGNAL(valueChanged(int)),
+            this, SLOT(setConstraintIters(int)));
     connect(m_settingsWidget, SIGNAL(destroyed()),
             this, SLOT(settingsWidgetDestroyed()));
     m_settingsWidget->lengthSpinBox->setValue(m_length);
     m_settingsWidget->countSpinBox->setValue(m_count);
+    m_settingsWidget->modelComboBox->setCurrentIndex(m_settings.model);
+    m_settingsWidget->alphaSpinBox->setValue(m_settings.alpha);
+    m_settingsWidget->lagSpinBox->setValue(m_settings.lagFactor);
+    m_settingsWidget->freqSpinBox->setValue(m_settings.naturalFreq);
+    m_settingsWidget->nodesSpinBox->setValue(m_settings.nodesPerStrand);
+    m_settingsWidget->stiffnessSpinBox->setValue(m_settings.stiffness);
+    m_settingsWidget->dragSpinBox->setValue(m_settings.drag);
+    m_settingsWidget->iterSpinBox->setValue(m_settings.constraintIters);
   }
   return m_settingsWidget;
 }
@@ -216,12 +366,73 @@ void HairEngine::setLength(double value)
 void HairEngine::setCount(int value)
 {
   m_count = value;
+  clearState();
+  emit changed();
+}
+
+void HairEngine::setInertiaModel(int value)
+{
+  m_settings.model = static_cast<InertiaModel>(value);
+  clearState();
+  emit changed();
+}
+
+void HairEngine::setAlpha(double value)
+{
+  m_settings.alpha = value;
+  emit changed();
+}
+
+void HairEngine::setLagFactor(double value)
+{
+  m_settings.lagFactor = value;
+  emit changed();
+}
+
+void HairEngine::setNaturalFreq(double value)
+{
+  m_settings.naturalFreq = value;
+  emit changed();
+}
+
+void HairEngine::setNodes(int value)
+{
+  m_settings.nodesPerStrand = value;
+  clearState();
+  emit changed();
+}
+
+void HairEngine::setStiffness(double value)
+{
+  m_settings.stiffness = value;
+  emit changed();
+}
+
+void HairEngine::setDrag(double value)
+{
+  m_settings.drag = value;
+  emit changed();
+}
+
+void HairEngine::setConstraintIters(int value)
+{
+  m_settings.constraintIters = value;
   emit changed();
 }
 
 void HairEngine::settingsWidgetDestroyed()
 {
   m_settingsWidget = 0;
+}
+
+void HairEngine::clearState()
+{
+  m_prevPos.clear();
+  m_prevVel.clear();
+  m_smoothVel.clear();
+  m_springStrands.clear();
+  m_massStrands.clear();
+  m_hasPrevModelView = false;
 }
 
 double HairEngine::radius(const PainterDevice *, const Primitive *) const
@@ -239,6 +450,14 @@ void HairEngine::writeSettings(QSettings &settings) const
   Engine::writeSettings(settings);
   settings.setValue("length", m_length);
   settings.setValue("count", m_count);
+  settings.setValue("model", static_cast<int>(m_settings.model));
+  settings.setValue("alpha", m_settings.alpha);
+  settings.setValue("lagFactor", m_settings.lagFactor);
+  settings.setValue("naturalFreq", m_settings.naturalFreq);
+  settings.setValue("nodesPerStrand", m_settings.nodesPerStrand);
+  settings.setValue("stiffness", m_settings.stiffness);
+  settings.setValue("drag", m_settings.drag);
+  settings.setValue("constraintIters", m_settings.constraintIters);
 }
 
 void HairEngine::readSettings(QSettings &settings)
@@ -246,10 +465,26 @@ void HairEngine::readSettings(QSettings &settings)
   Engine::readSettings(settings);
   setLength(settings.value("length", 0.5).toDouble());
   setCount(settings.value("count", 10).toInt());
+  setInertiaModel(settings.value("model", 0).toInt());
+  setAlpha(settings.value("alpha", 0.2).toDouble());
+  setLagFactor(settings.value("lagFactor", 1.0).toDouble());
+  setNaturalFreq(settings.value("naturalFreq", 15.0).toDouble());
+  setNodes(settings.value("nodesPerStrand", 5).toInt());
+  setStiffness(settings.value("stiffness", 0.7).toDouble());
+  setDrag(settings.value("drag", 0.03).toDouble());
+  setConstraintIters(settings.value("constraintIters", 3).toInt());
   if (m_settingsWidget)
   {
     m_settingsWidget->lengthSpinBox->setValue(m_length);
     m_settingsWidget->countSpinBox->setValue(m_count);
+    m_settingsWidget->modelComboBox->setCurrentIndex(m_settings.model);
+    m_settingsWidget->alphaSpinBox->setValue(m_settings.alpha);
+    m_settingsWidget->lagSpinBox->setValue(m_settings.lagFactor);
+    m_settingsWidget->freqSpinBox->setValue(m_settings.naturalFreq);
+    m_settingsWidget->nodesSpinBox->setValue(m_settings.nodesPerStrand);
+    m_settingsWidget->stiffnessSpinBox->setValue(m_settings.stiffness);
+    m_settingsWidget->dragSpinBox->setValue(m_settings.drag);
+    m_settingsWidget->iterSpinBox->setValue(m_settings.constraintIters);
   }
 }
 

--- a/libavogadro/src/engines/hairengine.h
+++ b/libavogadro/src/engines/hairengine.h
@@ -121,6 +121,7 @@ private:
   int m_count;
   QElapsedTimer m_timer;       ///< Timer used for animation phases.
   QElapsedTimer m_frameTimer;  ///< Tracks per-frame time step.
+  unsigned int m_frameCount;   ///< Incremented each frame for RNG.
   QHash<unsigned int, Eigen::Vector3d> m_prevPos;
   QHash<unsigned int, Eigen::Vector3d> m_prevVel;
   QHash<unsigned int, Eigen::Vector3d> m_smoothVel;

--- a/libavogadro/src/engines/hairsettingswidget.ui
+++ b/libavogadro/src/engines/hairsettingswidget.ui
@@ -48,13 +48,209 @@
     <property name="maximum">
      <number>999999</number>
     </property>
+   <property name="value">
+    <number>10</number>
+   </property>
+  </widget>
+ </item>
+  <item row="2" column="0">
+   <widget class="QLabel" name="labelModel">
+    <property name="text">
+     <string>Inertia Model:</string>
+    </property>
+   </widget>
+  </item>
+  <item row="2" column="1">
+   <widget class="QComboBox" name="modelComboBox">
+    <item>
+     <property name="text">
+      <string>Simple EMA</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>Spring-Lag</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>Mass-Spring</string>
+     </property>
+    </item>
+   </widget>
+  </item>
+  <item row="3" column="0">
+   <widget class="QLabel" name="labelAlpha">
+    <property name="text">
+     <string>EMA Alpha:</string>
+    </property>
+   </widget>
+  </item>
+  <item row="3" column="1">
+   <widget class="QDoubleSpinBox" name="alphaSpinBox">
+    <property name="decimals">
+     <number>2</number>
+    </property>
+    <property name="minimum">
+     <double>0.05</double>
+    </property>
+    <property name="maximum">
+     <double>0.5</double>
+    </property>
+    <property name="singleStep">
+     <double>0.01</double>
+    </property>
     <property name="value">
-     <number>10</number>
+     <double>0.2</double>
+    </property>
+   </widget>
+  </item>
+  <item row="4" column="0">
+   <widget class="QLabel" name="labelLag">
+    <property name="text">
+     <string>Lag Factor:</string>
+    </property>
+   </widget>
+  </item>
+  <item row="4" column="1">
+   <widget class="QDoubleSpinBox" name="lagSpinBox">
+    <property name="decimals">
+     <number>2</number>
+    </property>
+    <property name="minimum">
+     <double>0.0</double>
+    </property>
+    <property name="maximum">
+     <double>5.0</double>
+    </property>
+    <property name="singleStep">
+     <double>0.1</double>
+    </property>
+    <property name="value">
+     <double>1.0</double>
+    </property>
+   </widget>
+  </item>
+  <item row="5" column="0">
+   <widget class="QLabel" name="labelFreq">
+    <property name="text">
+     <string>Natural Freq (&#x03C9;&#x2080; rad/s):</string>
+    </property>
+   </widget>
+  </item>
+  <item row="5" column="1">
+   <widget class="QDoubleSpinBox" name="freqSpinBox">
+    <property name="decimals">
+     <number>1</number>
+    </property>
+    <property name="minimum">
+     <double>5.0</double>
+    </property>
+    <property name="maximum">
+     <double>30.0</double>
+    </property>
+    <property name="singleStep">
+     <double>1.0</double>
+    </property>
+    <property name="value">
+     <double>15.0</double>
+    </property>
+   </widget>
+  </item>
+  <item row="6" column="0">
+   <widget class="QLabel" name="labelNodes">
+    <property name="text">
+     <string>Nodes per Strand:</string>
+    </property>
+   </widget>
+  </item>
+  <item row="6" column="1">
+   <widget class="QSpinBox" name="nodesSpinBox">
+    <property name="minimum">
+     <number>3</number>
+    </property>
+    <property name="maximum">
+     <number>8</number>
+    </property>
+    <property name="value">
+     <number>5</number>
+    </property>
+   </widget>
+  </item>
+  <item row="7" column="0">
+   <widget class="QLabel" name="labelStiffness">
+    <property name="text">
+     <string>Stiffness:</string>
+    </property>
+   </widget>
+  </item>
+  <item row="7" column="1">
+   <widget class="QDoubleSpinBox" name="stiffnessSpinBox">
+    <property name="decimals">
+     <number>2</number>
+    </property>
+    <property name="minimum">
+     <double>0.0</double>
+    </property>
+    <property name="maximum">
+     <double>1.0</double>
+    </property>
+    <property name="singleStep">
+     <double>0.01</double>
+    </property>
+    <property name="value">
+     <double>0.7</double>
+    </property>
+   </widget>
+  </item>
+  <item row="8" column="0">
+   <widget class="QLabel" name="labelDrag">
+    <property name="text">
+     <string>Drag:</string>
+    </property>
+   </widget>
+  </item>
+  <item row="8" column="1">
+   <widget class="QDoubleSpinBox" name="dragSpinBox">
+    <property name="decimals">
+     <number>2</number>
+    </property>
+    <property name="minimum">
+     <double>0.0</double>
+    </property>
+    <property name="maximum">
+     <double>1.0</double>
+    </property>
+    <property name="singleStep">
+     <double>0.01</double>
+    </property>
+    <property name="value">
+     <double>0.03</double>
+    </property>
+   </widget>
+  </item>
+  <item row="9" column="0">
+   <widget class="QLabel" name="labelIter">
+    <property name="text">
+     <string>Constraint Iterations:</string>
+    </property>
+   </widget>
+  </item>
+  <item row="9" column="1">
+   <widget class="QSpinBox" name="iterSpinBox">
+    <property name="minimum">
+     <number>1</number>
+    </property>
+    <property name="maximum">
+     <number>6</number>
+    </property>
+    <property name="value">
+     <number>3</number>
     </property>
    </widget>
   </item>
   </layout>
- </widget>
+</widget>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
## Summary
- extend HairEngine to support three inertia models
- add per-frame timer and physics parameters
- expose new settings in HairSettingsWidget

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON` *(passes)*
- `cmake --build build -- -j$(nproc)` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6877ad57c9dc8333a453cdf0bcc93a60