### PR TITLE
Add xTB installer workflow

### DIFF
--- a/.github/workflows/windows-installer-test.yml
+++ b/.github/workflows/windows-installer-test.yml
@@ -1,0 +1,28 @@
+name: Windows Installer Test
+on:
+  workflow_run:
+    workflows: ["Windows xTB Installer"]
+    types:
+      - completed
+
+jobs:
+  install-test:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: windows-latest
+    steps:
+      - name: Download installer artifact
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: avogadro-windows-xtb-installer
+          path: installer
+      - name: Install Avogadro
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem installer\*.exe | Select-Object -First 1
+          & $exe /S
+      - name: List install directory
+        shell: cmd
+        run: |
+          tree /f "C:\Program Files (x86)\Avogadro"

--- a/.github/workflows/windows-xtb-installer.yml
+++ b/.github/workflows/windows-xtb-installer.yml
@@ -1,4 +1,4 @@
-name: Windows Installer
+name: Windows xTB Installer
 on:
   workflow_dispatch:
   push:
@@ -21,6 +21,8 @@ jobs:
           --no-progress `
           --installargs '"ADD_CMAKE_TO_PATH=System"' `
           --allow-downgrade   # harmless if no newer CMake is present
+      - name: Install pkg-config
+        run: choco install -y pkgconfiglite
       - name: Build zlib
         shell: pwsh
         run: |
@@ -138,6 +140,101 @@ jobs:
           "OPENBABEL3_LIBRARY_DIRS=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "OPENBABEL_INSTALL_DIR=$obDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "$obDir\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Cache oneAPI BaseKit 2024.1 installer
+        id: cache-oneapi-base
+        uses: actions/cache@v4
+        with:
+          key: oneapi-base-2024.1-win64
+          path: ${{ runner.temp }}\w_BaseKit_p_2024.1.0.595_offline.exe
+
+      - name: Cache oneAPI HPC Toolkit 2024.1 installer
+        id: cache-oneapi-hpc
+        uses: actions/cache@v4
+        with:
+          key: oneapi-hpc-2024.1-win64
+          path: ${{ runner.temp }}\w_HPCKit_p_2024.1.0.561_offline.exe
+
+      - name: Download Intel oneAPI BaseKit 2024.1 offline installer
+        if: steps.cache-oneapi-base.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $url = "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7dff44ba-e3af-4448-841c-0d616c8da6e7/w_BaseKit_p_2024.1.0.595_offline.exe"
+          $dst = "$env:RUNNER_TEMP\w_BaseKit_p_2024.1.0.595_offline.exe"
+          Invoke-WebRequest $url -OutFile $dst
+
+      - name: Download Intel oneAPI HPC Toolkit 2024.1 offline installer
+        if: steps.cache-oneapi-hpc.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $url = "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c95a3b26-fc45-496c-833b-df08b10297b9/w_HPCKit_p_2024.1.0.561_offline.exe"
+          $dst = "$env:RUNNER_TEMP\w_HPCKit_p_2024.1.0.561_offline.exe"
+          Invoke-WebRequest $url -OutFile $dst
+
+      - name: Install oneAPI BaseKit 2024.1 (silent)
+        shell: cmd
+        run: |
+          "%RUNNER_TEMP%\w_BaseKit_p_2024.1.0.595_offline.exe" ^
+              -a --silent --eula accept ^
+              --install-dir "C:\Program Files (x86)\Intel\oneAPI"
+
+      - name: Install oneAPI HPC Toolkit 2024.1 (silent)
+        shell: cmd
+        run: |
+          "%RUNNER_TEMP%\w_HPCKit_p_2024.1.0.561_offline.exe" ^
+              -a --silent --eula accept ^
+              --install-dir "C:\Program Files (x86)\Intel\oneAPI"
+
+      - name: Load oneAPI environment
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+          where icl
+          where ifort
+          echo MKLROOT=%MKLROOT%>>"%GITHUB_ENV%"
+          echo ONEAPI_ROOT=%ONEAPI_ROOT%>>"%GITHUB_ENV%"
+          echo CC=cl>>"%GITHUB_ENV%"
+          echo CXX=cl>>"%GITHUB_ENV%"
+          echo FC=ifort>>"%GITHUB_ENV%"
+          echo %ONEAPI_ROOT%\compiler\latest\windows\bin\intel64>>"%GITHUB_PATH%"
+          echo LIB=%LIB%>>"%GITHUB_ENV%"
+
+      - name: Download xTB
+        shell: pwsh
+        run: |
+          $release = Invoke-RestMethod https://api.github.com/repos/grimme-lab/xtb/releases/latest
+          $asset = $release.assets | Where-Object { $_.name -like '*windows-x86_64.zip' } | Select-Object -First 1
+          $zip = "$env:RUNNER_TEMP\xtb.zip"
+          Invoke-WebRequest $asset.browser_download_url -OutFile $zip
+          Expand-Archive $zip -DestinationPath $env:RUNNER_TEMP
+          $xtbDir = Get-ChildItem -Directory -Path $env:RUNNER_TEMP -Filter 'xtb-*' | Select-Object -First 1 -ExpandProperty FullName
+          $pcDir = Join-Path $xtbDir 'lib\pkgconfig'
+          $pcFiles = Get-ChildItem $pcDir -Filter '*.pc'
+          $mkl = "$env:MKLROOT/lib/intel64"
+          $omp = "$env:ONEAPI_ROOT/compiler/latest/windows/compiler/lib/intel64_win"
+          $prefixLine = 'prefix=' + ($xtbDir -replace '\\','/')
+          foreach ($pc in $pcFiles) {
+            $lines = Get-Content $pc | ForEach-Object {
+              if ($_ -match '^prefix=') { $prefixLine }
+              elseif ($_ -match '^Libs:') { $_ + " -L$($mkl -replace '\\','/') -L$($omp -replace '\\','/') -lmkl_rt -llibiomp5md" }
+              else { $_ }
+            }
+            Set-Content -Path $pc -Value $lines
+          }
+          "XTB_DIR=$xtbDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "PKG_CONFIG_PATH=$xtbDir\lib\pkgconfig;$env:PKG_CONFIG_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "$xtbDir\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "LIB=$xtbDir\lib;$env:LIB" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Convert xTB libraries
+        shell: pwsh
+        run: |
+          Get-ChildItem "$env:XTB_DIR\lib\*.a" | ForEach-Object {
+            $base = $_.BaseName
+            if ($base -like 'lib*') { $base = $base.Substring(3) }
+            $out = Join-Path $_.Directory "$base.lib"
+            Write-Host "Converting $($_.FullName) -> $out"
+            lib /verbose /nologo /machine:X64 /out:$out $_.FullName
+          }
       - name: Configure
         shell: pwsh
         run: |
@@ -158,11 +255,31 @@ jobs:
             "-DOPENBABEL3_LIBRARY_DIRS=$env:OPENBABEL3_LIBRARY_DIRS" `
             "-DOPENBABEL_INSTALL_DIR=$env:OPENBABEL_INSTALL_DIR" `
             "-DGLEW_INCLUDE_DIR=$env:GLEW_INCLUDE_DIR" `
-            "-DGLEW_LIBRARY=$env:GLEW_LIBRARY"
+            "-DGLEW_LIBRARY=$env:GLEW_LIBRARY" `
+            -DENABLE_XTB_OPTTOOL=ON
       - name: Build
         shell: pwsh
         run: |
           cmake --build build --config Release --target install
+      - name: Copy Intel redist DLLs
+        shell: pwsh
+        run: |
+          $distBin = Join-Path $pwd 'scripts/installer/dist/bin'
+          $dllDir = $null
+          if ($env:ONEAPI_ROOT) {
+            $try = Get-ChildItem -Path (Join-Path $env:ONEAPI_ROOT 'compiler') -Directory | ForEach-Object {
+              Join-Path $_ 'windows\redist\intel64'
+            } | Where-Object { Test-Path $_ } | Select-Object -First 1
+            if ($try) { $dllDir = $try }
+          }
+          if (-not $dllDir) {
+            $dllDir = python -c "import os, pathlib; root=os.environ.get('ONEAPI_ROOT', r'C:\\Program Files (x86)\\Intel\\oneAPI'); path=sorted(pathlib.Path(root).glob('compiler/*/windows/redist/intel64')); print(path[0] if path else '')"
+          }
+          if (-not $dllDir -or !(Test-Path $dllDir)) { throw 'Intel redist directory not found' }
+          Get-ChildItem $dllDir -Filter *.dll | ForEach-Object {
+            Copy-Item $_ $distBin -Force
+            Write-Host "Copied $($_.Name)"
+          }
       - name: Create installer
         shell: pwsh
         run: |
@@ -170,7 +287,7 @@ jobs:
       - name: Upload installer
         uses: actions/upload-artifact@v4
         with:
-          name: avogadro-windows-installer
+          name: avogadro-windows-xtb-installer
           path: |
             scripts/installer/avogadro-win32-*.exe
           if-no-files-found: error

--- a/libavogadro/src/tools/xtbopttool.cpp
+++ b/libavogadro/src/tools/xtbopttool.cpp
@@ -11,6 +11,8 @@
 #include <QtWidgets/QVBoxLayout>
 #include <QtWidgets/QProgressBar>
 #include <QtCore/QElapsedTimer>
+#include <QtCore/QCoreApplication>
+#include <QtCore/QDir>
 #include <Eigen/Core>
 #include <QtCore/QMutexLocker>
 
@@ -389,6 +391,13 @@ bool XtbOptThread::setup(Molecule *mol, int method, int engine, int level,
   m_molecule = mol;
   m_steps = steps;
   m_stop = false;
+
+  if (qEnvironmentVariableIsEmpty("XTBPATH")) {
+    QDir dir(QCoreApplication::applicationDirPath());
+    dir.cdUp();
+    QString share = dir.filePath("share/xtb");
+    qputenv("XTBPATH", QDir::toNativeSeparators(share).toLocal8Bit());
+  }
 
   m_env = xtb_newEnvironment();
   if (!m_env) {


### PR DESCRIPTION
## Summary
- introduce Windows xTB Installer workflow for oneAPI/xTB builds
- copy xTB files in installer script
- fix indentation in workflow YAML
- patch pkg-config with proper PowerShell syntax

## Testing
- `sudo apt-get update`
- `sudo xargs -a .github/apt-packages.txt apt-get install -y`
- `python -m py_compile scripts/installer/create_installer.py`


------
https://chatgpt.com/codex/tasks/task_e_686ae48292548333bc6a7d650b5fa431