### PR TITLE
Fix OpenBabel integration for xtb installer

### DIFF
--- a/.github/workflows/windows-xtb-installer.yml
+++ b/.github/workflows/windows-xtb-installer.yml
@@ -188,7 +188,12 @@ jobs:
           $pcDir = Join-Path $xtbDir 'lib\pkgconfig'
           $pcFiles = Get-ChildItem $pcDir -Filter '*.pc'
           $mkl = "$env:MKLROOT/lib/intel64"
-          $omp = "$env:ONEAPI_ROOT/compiler/latest/windows/compiler/lib/intel64_win"
+          $omp = Get-ChildItem $env:ONEAPI_ROOT -Directory | ForEach-Object {
+            Join-Path $_ 'compiler\lib\intel64_win'
+          } | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $omp) {
+            $omp = "$env:ONEAPI_ROOT/compiler/latest/windows/compiler/lib/intel64_win"
+          }
           $prefixLine = 'prefix=' + ($xtbDir -replace '\\','/')
           $libsSuffix = " /LIBPATH:`"$mkl`" /LIBPATH:`"$omp`" mkl_rt.lib libiomp5md.lib"
           foreach ($pc in $pcFiles) {

--- a/.github/workflows/windows-xtb-installer.yml
+++ b/.github/workflows/windows-xtb-installer.yml
@@ -240,15 +240,29 @@ jobs:
         shell: pwsh
         run: |
           $distBin = Join-Path $pwd 'scripts/installer/dist/bin'
+
+          # 1. classic (<=2023) layout under %ONEAPI_ROOT%\compiler\<ver>\windows\redist
           $root = if ($env:ONEAPI_ROOT) { $env:ONEAPI_ROOT } else { 'C:\Program Files (x86)\Intel\oneAPI' }
-          $candidates = Get-ChildItem (Join-Path $root 'compiler') -Directory |
-            ForEach-Object {
-              @( Join-Path $_ 'windows\redist\intel64_win\compiler' )
-              @( Join-Path $_ 'windows\redist\intel64\compiler' )
-            }
+          $candidates = Get-ChildItem (Join-Path $root 'compiler') -Directory | ForEach-Object {
+            Join-Path $_ 'windows\redist\intel64_win\compiler'
+            Join-Path $_ 'windows\redist\intel64\compiler'
+          }
+
+          # 2. unified (2024+) layout, if available
+          if ($env:INTEL_DEV_REDIST) {
+            $candidates += Join-Path $env:INTEL_DEV_REDIST 'redist\intel64_win\compiler'
+            $candidates += Join-Path $env:INTEL_DEV_REDIST 'redist\intel64\compiler'
+          }
+
+          # 3. final hard-coded fallback
+          $candidates += 'C:\Program Files (x86)\Common Files\Intel\Shared Libraries\redist\intel64_win\compiler'
+
           $dllDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $dllDir) { throw 'Intel redist directory not found' }
-          Copy-Item -Path (Join-Path $dllDir '*.dll') -Destination $distBin -Recurse -Force
+          if (-not $dllDir) {
+            Write-Host "Checked paths: $($candidates -join ';')"
+            throw 'Intel redistributable directory not found - check toolkit install.'
+          }
+          Copy-Item (Join-Path $dllDir '*.dll') $distBin -Recurse -Force
       - name: Create installer
         shell: pwsh
         run: |

--- a/.github/workflows/windows-xtb-installer.yml
+++ b/.github/workflows/windows-xtb-installer.yml
@@ -243,7 +243,10 @@ jobs:
           $root = $env:ONEAPI_ROOT
           if (-not $root) { $root = 'C:\\Program Files (x86)\\Intel\\oneAPI' }
           $dllDir = Get-ChildItem -Path (Join-Path $root 'compiler') -Directory |
-            ForEach-Object { Join-Path $_ 'windows\redist\intel64' } |
+            ForEach-Object {
+              $p = Join-Path $_ 'windows\redist\intel64_win'
+              if (Test-Path $p) { $p } else { Join-Path $_ 'windows\redist\intel64' }
+            } |
             Where-Object { Test-Path $_ } | Select-Object -First 1
           if (-not $dllDir) { throw 'Intel redist directory not found' }
           Get-ChildItem $dllDir -Filter *.dll | ForEach-Object {

--- a/.github/workflows/windows-xtb-installer.yml
+++ b/.github/workflows/windows-xtb-installer.yml
@@ -240,7 +240,7 @@ jobs:
         shell: pwsh
         run: |
           $distBin = Join-Path $pwd 'scripts/installer/dist/bin'
-          $root = if ($env:ONEAPI_ROOT) { $env:ONEAPI_ROOT } else { 'C:\\Program Files (x86)\\Intel\\oneAPI' }
+          $root = if ($env:ONEAPI_ROOT) { $env:ONEAPI_ROOT } else { 'C:\Program Files (x86)\Intel\oneAPI' }
           $candidates = Get-ChildItem (Join-Path $root 'compiler') -Directory |
             ForEach-Object {
               @( Join-Path $_ 'windows\redist\intel64_win\compiler' )

--- a/.github/workflows/windows-xtb-installer.yml
+++ b/.github/workflows/windows-xtb-installer.yml
@@ -240,19 +240,15 @@ jobs:
         shell: pwsh
         run: |
           $distBin = Join-Path $pwd 'scripts/installer/dist/bin'
-          $root = $env:ONEAPI_ROOT
-          if (-not $root) { $root = 'C:\\Program Files (x86)\\Intel\\oneAPI' }
-          $dllDir = Get-ChildItem -Path (Join-Path $root 'compiler') -Directory |
+          $root = if ($env:ONEAPI_ROOT) { $env:ONEAPI_ROOT } else { 'C:\\Program Files (x86)\\Intel\\oneAPI' }
+          $candidates = Get-ChildItem (Join-Path $root 'compiler') -Directory |
             ForEach-Object {
-              $p = Join-Path $_ 'windows\redist\intel64_win'
-              if (Test-Path $p) { $p } else { Join-Path $_ 'windows\redist\intel64' }
-            } |
-            Where-Object { Test-Path $_ } | Select-Object -First 1
+              @( Join-Path $_ 'windows\redist\intel64_win\compiler' )
+              @( Join-Path $_ 'windows\redist\intel64\compiler' )
+            }
+          $dllDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
           if (-not $dllDir) { throw 'Intel redist directory not found' }
-          Get-ChildItem $dllDir -Filter *.dll | ForEach-Object {
-            Copy-Item $_ $distBin -Force
-            Write-Host "Copied $($_.Name)"
-          }
+          Copy-Item -Path (Join-Path $dllDir '*.dll') -Destination $distBin -Recurse -Force
       - name: Create installer
         shell: pwsh
         run: |

--- a/.github/workflows/windows-xtb-installer.yml
+++ b/.github/workflows/windows-xtb-installer.yml
@@ -118,28 +118,6 @@ jobs:
           "CMAKE_LIBRARY_PATH=$libDir;$env:CMAKE_LIBRARY_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_PREFIX_PATH=$installDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "$binDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Build OpenBabel
-        shell: pwsh
-        run: |
-          $srcDir = Join-Path $env:RUNNER_TEMP 'openbabel-src'
-          git clone --depth 1 https://github.com/thosoo/openbabel $srcDir
-          $build = Join-Path $srcDir 'build'
-          cmake -S $srcDir -B $build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$build\install" -DLIBXML2_LIBRARY="$env:LIBXML2_LIBRARY" -DLIBXML2_LIBRARIES="$env:LIBXML2_LIBRARY" -DLIBXML2_INCLUDE_DIR="$env:LIBXML2_INCLUDE_DIR" -DZLIB_LIBRARY="$env:ZLIB_LIBRARY" -DZLIB_INCLUDE_DIR="$env:ZLIB_INCLUDE_DIR" -DBUILD_SHARED=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DOB_USE_PREBUILT_BINARIES=OFF -DOPENBABEL_USE_SYSTEM_INCHI=OFF -DWITH_INCHI=ON
-          Push-Location $build
-          nmake install
-          Pop-Location
-          $obDir = Join-Path $build 'install'
-          $inc = Join-Path $obDir 'include' 'openbabel3'
-          $lib = Join-Path $obDir 'lib' 'openbabel.lib'
-          Copy-Item (Join-Path $obDir 'bin' 'openbabel-3.lib') $lib -Force
-          Copy-Item (Join-Path $obDir 'bin' 'openbabel-3.dll') (Join-Path $obDir 'bin' 'openbabel.dll') -Force
-          $libDir = Join-Path $obDir 'lib'
-          "CMAKE_PREFIX_PATH=$obDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENBABEL3_INCLUDE_DIR=$inc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENBABEL3_LIBRARIES=$lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENBABEL3_LIBRARY_DIRS=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENBABEL_INSTALL_DIR=$obDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "$obDir\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Cache oneAPI BaseKit 2024.1 installer
         id: cache-oneapi-base
         uses: actions/cache@v4
@@ -251,10 +229,6 @@ jobs:
             "-DEIGEN3_INCLUDE_DIR=$env:EIGEN3_INCLUDE_DIR" `
             "-DLIBXML2_LIBRARY=$env:LIBXML2_LIBRARY" `
             "-DLIBXML2_INCLUDE_DIR=$env:LIBXML2_INCLUDE_DIR" `
-            "-DOPENBABEL3_INCLUDE_DIR=$env:OPENBABEL3_INCLUDE_DIR" `
-            "-DOPENBABEL3_LIBRARIES=$env:OPENBABEL3_LIBRARIES" `
-            "-DOPENBABEL3_LIBRARY_DIRS=$env:OPENBABEL3_LIBRARY_DIRS" `
-            "-DOPENBABEL_INSTALL_DIR=$env:OPENBABEL_INSTALL_DIR" `
             "-DGLEW_INCLUDE_DIR=$env:GLEW_INCLUDE_DIR" `
             "-DGLEW_LIBRARY=$env:GLEW_LIBRARY" `
             -DENABLE_XTB_OPTTOOL=ON

--- a/.github/workflows/windows-xtb-installer.yml
+++ b/.github/workflows/windows-xtb-installer.yml
@@ -239,19 +239,7 @@ jobs:
       - name: Copy Intel redist DLLs
         shell: pwsh
         run: |
-          $distBin = Join-Path $pwd 'scripts/installer/dist/bin'
-          $root    = if ($env:ONEAPI_ROOT) { $env:ONEAPI_ROOT } else { 'C:\Program Files (x86)\Intel\oneAPI' }
-
-          $candidates = Get-ChildItem (Join-Path $root 'compiler') -Directory |
-            ForEach-Object {
-              @( Join-Path $_ 'windows\redist\intel64_win\compiler' )
-              @( Join-Path $_ 'windows\redist\intel64\compiler'      )
-            }
-
-          $dllDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $dllDir) { throw 'Intel redist directory not found' }
-
-          Copy-Item -Path (Join-Path $dllDir '*.dll') -Destination $distBin -Recurse -Force
+          & "${{ github.workspace }}\ci\copy_intel_redist.ps1"
       - name: Create installer
         shell: pwsh
         run: |

--- a/.github/workflows/windows-xtb-installer.yml
+++ b/.github/workflows/windows-xtb-installer.yml
@@ -118,6 +118,28 @@ jobs:
           "CMAKE_LIBRARY_PATH=$libDir;$env:CMAKE_LIBRARY_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_PREFIX_PATH=$installDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "$binDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Build OpenBabel
+        shell: pwsh
+        run: |
+          $srcDir = Join-Path $env:RUNNER_TEMP 'openbabel-src'
+          git clone --depth 1 https://github.com/thosoo/openbabel $srcDir
+          $build = Join-Path $srcDir 'build'
+          cmake -S $srcDir -B $build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$build\install" -DLIBXML2_LIBRARY="$env:LIBXML2_LIBRARY" -DLIBXML2_LIBRARIES="$env:LIBXML2_LIBRARY" -DLIBXML2_INCLUDE_DIR="$env:LIBXML2_INCLUDE_DIR" -DZLIB_LIBRARY="$env:ZLIB_LIBRARY" -DZLIB_INCLUDE_DIR="$env:ZLIB_INCLUDE_DIR" -DBUILD_SHARED=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DOB_USE_PREBUILT_BINARIES=OFF -DOPENBABEL_USE_SYSTEM_INCHI=OFF -DWITH_INCHI=ON
+          Push-Location $build
+          nmake install
+          Pop-Location
+          $obDir = Join-Path $build 'install'
+          $inc = Join-Path $obDir 'include' 'openbabel3'
+          $lib = Join-Path $obDir 'lib' 'openbabel.lib'
+          Copy-Item (Join-Path $obDir 'bin' 'openbabel-3.lib') $lib -Force
+          Copy-Item (Join-Path $obDir 'bin' 'openbabel-3.dll') (Join-Path $obDir 'bin' 'openbabel.dll') -Force
+          $libDir = Join-Path $obDir 'lib'
+          "CMAKE_PREFIX_PATH=$obDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENBABEL3_INCLUDE_DIR=$inc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENBABEL3_LIBRARIES=$lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENBABEL3_LIBRARY_DIRS=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENBABEL_INSTALL_DIR=$obDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "$obDir\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Cache oneAPI BaseKit 2024.1 installer
         id: cache-oneapi-base
         uses: actions/cache@v4
@@ -229,6 +251,10 @@ jobs:
             "-DEIGEN3_INCLUDE_DIR=$env:EIGEN3_INCLUDE_DIR" `
             "-DLIBXML2_LIBRARY=$env:LIBXML2_LIBRARY" `
             "-DLIBXML2_INCLUDE_DIR=$env:LIBXML2_INCLUDE_DIR" `
+            "-DOPENBABEL3_INCLUDE_DIR=$env:OPENBABEL3_INCLUDE_DIR" `
+            "-DOPENBABEL3_LIBRARIES=$env:OPENBABEL3_LIBRARIES" `
+            "-DOPENBABEL3_LIBRARY_DIRS=$env:OPENBABEL3_LIBRARY_DIRS" `
+            "-DOPENBABEL_INSTALL_DIR=$env:OPENBABEL_INSTALL_DIR" `
             "-DGLEW_INCLUDE_DIR=$env:GLEW_INCLUDE_DIR" `
             "-DGLEW_LIBRARY=$env:GLEW_LIBRARY" `
             -DENABLE_XTB_OPTTOOL=ON
@@ -236,6 +262,10 @@ jobs:
         shell: pwsh
         run: |
           cmake --build build --config Release --target install
+      - name: Inspect ONEAPI_ROOT
+        shell: cmd
+        run: |
+          tree /f "%ONEAPI_ROOT%"
       - name: Copy Intel redist DLLs
         shell: pwsh
         run: |

--- a/.github/workflows/windows-xtb-installer.yml
+++ b/.github/workflows/windows-xtb-installer.yml
@@ -240,29 +240,18 @@ jobs:
         shell: pwsh
         run: |
           $distBin = Join-Path $pwd 'scripts/installer/dist/bin'
+          $root    = if ($env:ONEAPI_ROOT) { $env:ONEAPI_ROOT } else { 'C:\Program Files (x86)\Intel\oneAPI' }
 
-          # 1. classic (<=2023) layout under %ONEAPI_ROOT%\compiler\<ver>\windows\redist
-          $root = if ($env:ONEAPI_ROOT) { $env:ONEAPI_ROOT } else { 'C:\Program Files (x86)\Intel\oneAPI' }
-          $candidates = Get-ChildItem (Join-Path $root 'compiler') -Directory | ForEach-Object {
-            Join-Path $_ 'windows\redist\intel64_win\compiler'
-            Join-Path $_ 'windows\redist\intel64\compiler'
-          }
-
-          # 2. unified (2024+) layout, if available
-          if ($env:INTEL_DEV_REDIST) {
-            $candidates += Join-Path $env:INTEL_DEV_REDIST 'redist\intel64_win\compiler'
-            $candidates += Join-Path $env:INTEL_DEV_REDIST 'redist\intel64\compiler'
-          }
-
-          # 3. final hard-coded fallback
-          $candidates += 'C:\Program Files (x86)\Common Files\Intel\Shared Libraries\redist\intel64_win\compiler'
+          $candidates = Get-ChildItem (Join-Path $root 'compiler') -Directory |
+            ForEach-Object {
+              @( Join-Path $_ 'windows\redist\intel64_win\compiler' )
+              @( Join-Path $_ 'windows\redist\intel64\compiler'      )
+            }
 
           $dllDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $dllDir) {
-            Write-Host "Checked paths: $($candidates -join ';')"
-            throw 'Intel redistributable directory not found - check toolkit install.'
-          }
-          Copy-Item (Join-Path $dllDir '*.dll') $distBin -Recurse -Force
+          if (-not $dllDir) { throw 'Intel redist directory not found' }
+
+          Copy-Item -Path (Join-Path $dllDir '*.dll') -Destination $distBin -Recurse -Force
       - name: Create installer
         shell: pwsh
         run: |

--- a/ci/copy_intel_redist.ps1
+++ b/ci/copy_intel_redist.ps1
@@ -1,21 +1,13 @@
+
 $distBin = Join-Path $pwd 'scripts/installer/dist/bin'
 $root    = if ($Env:ONEAPI_ROOT) { $Env:ONEAPI_ROOT } else { 'C:\Program Files (x86)\Intel\oneAPI' }
 
-# First probe the "latest" compiler redist directory (preferred)
-$dllDirCandidates = @(
-    Join-Path $root 'compiler\latest\windows\redist\intel64_win\compiler'
-    Join-Path $root 'compiler\latest\windows\redist\intel64\compiler'
-)
-
-# Fall back to scanning all compiler versions if none of the preferred paths exist
-if (-not ($dllDirCandidates | Where-Object { Test-Path $_ })) {
-    $dllDirCandidates = Get-ChildItem -Path (Join-Path $root 'compiler') -Directory | ForEach-Object {
-        @( Join-Path $_ 'windows\redist\intel64_win\compiler' )
-        @( Join-Path $_ 'windows\redist\intel64\compiler'      )
-    }
+$candidates = Get-ChildItem (Join-Path $root 'compiler') -Directory | ForEach-Object {
+    @( Join-Path $_ 'windows\redist\intel64_win\compiler' )
+    @( Join-Path $_ 'windows\redist\intel64\compiler'      )
 }
 
-$dllDir = $dllDirCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+$dllDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
 if (-not $dllDir) { throw 'Intel redist directory not found' }
 
 Copy-Item -Path (Join-Path $dllDir '*.dll') -Destination $distBin -Recurse -Force

--- a/ci/copy_intel_redist.ps1
+++ b/ci/copy_intel_redist.ps1
@@ -2,9 +2,9 @@
 $distBin = Join-Path $pwd 'scripts/installer/dist/bin'
 $root    = if ($Env:ONEAPI_ROOT) { $Env:ONEAPI_ROOT } else { 'C:\Program Files (x86)\Intel\oneAPI' }
 
-$candidates = Get-ChildItem (Join-Path $root 'compiler') -Directory | ForEach-Object {
-    @( Join-Path $_ 'windows\redist\intel64_win\compiler' )
-    @( Join-Path $_ 'windows\redist\intel64\compiler'      )
+$candidates = Get-ChildItem $root -Directory | ForEach-Object {
+    @( Join-Path $_ 'compiler\windows\redist\intel64_win\compiler' )
+    @( Join-Path $_ 'compiler\windows\redist\intel64\compiler'      )
 }
 
 $dllDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1

--- a/ci/copy_intel_redist.ps1
+++ b/ci/copy_intel_redist.ps1
@@ -2,9 +2,32 @@
 $distBin = Join-Path $pwd 'scripts/installer/dist/bin'
 $root    = if ($Env:ONEAPI_ROOT) { $Env:ONEAPI_ROOT } else { 'C:\Program Files (x86)\Intel\oneAPI' }
 
+# Probe all compiler versions for the redistributable folder
+$candidates = Get-ChildItem (Join-Path $root 'compiler') -Directory | ForEach-Object {
+    @( Join-Path $_ 'windows\redist\intel64_win\compiler' )
+    @( Join-Path $_ 'windows\redist\intel64\compiler' )
+}
 
-# DLLs are placed under <ONEAPI_ROOT>/2024.1/bin on the runners
-$dllDir = Join-Path $root '2024.1\bin'
-if (-not (Test-Path $dllDir)) { throw 'Intel redist directory not found' }
+$dllDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $dllDir) { throw 'Intel redist directory not found' }
 
-Copy-Item -Path (Join-Path $dllDir '*.dll') -Destination $distBin -Recurse -Force
+$dlls = @(
+    'libifcoremd.dll',
+    'libifcorert.dll',
+    'libifportmd.dll',
+    'libmmd.dll',
+    'libirc.dll',
+    'svml_dispmd.dll',
+    'libiomp5md.dll'
+)
+foreach ($dll in $dlls) {
+    $path = Join-Path $dllDir $dll
+    if (Test-Path $path) {
+        Copy-Item $path $distBin -Force
+    }
+}
+
+if ($Env:MKLROOT) {
+    $mkl = Join-Path $Env:MKLROOT 'redist\intel64\mkl_rt.dll'
+    if (Test-Path $mkl) { Copy-Item $mkl $distBin -Force }
+}

--- a/ci/copy_intel_redist.ps1
+++ b/ci/copy_intel_redist.ps1
@@ -1,0 +1,13 @@
+$distBin = Join-Path $pwd 'scripts/installer/dist/bin'
+$root    = if ($Env:ONEAPI_ROOT) { $Env:ONEAPI_ROOT } else { 'C:\Program Files (x86)\Intel\oneAPI' }
+
+$candidates = Get-ChildItem (Join-Path $root 'compiler') -Directory |
+    ForEach-Object {
+        @( Join-Path $_ 'windows\redist\intel64_win\compiler' )
+        @( Join-Path $_ 'windows\redist\intel64\compiler'      )
+    }
+
+$dllDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $dllDir) { throw 'Intel redist directory not found' }
+
+Copy-Item -Path (Join-Path $dllDir '*.dll') -Destination $distBin -Recurse -Force

--- a/ci/copy_intel_redist.ps1
+++ b/ci/copy_intel_redist.ps1
@@ -2,12 +2,9 @@
 $distBin = Join-Path $pwd 'scripts/installer/dist/bin'
 $root    = if ($Env:ONEAPI_ROOT) { $Env:ONEAPI_ROOT } else { 'C:\Program Files (x86)\Intel\oneAPI' }
 
-$candidates = Get-ChildItem $root -Directory | ForEach-Object {
-    @( Join-Path $_ 'compiler\windows\redist\intel64_win\compiler' )
-    @( Join-Path $_ 'compiler\windows\redist\intel64\compiler'      )
-}
 
-$dllDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-if (-not $dllDir) { throw 'Intel redist directory not found' }
+# DLLs are placed under <ONEAPI_ROOT>/2024.1/bin on the runners
+$dllDir = Join-Path $root '2024.1\bin'
+if (-not (Test-Path $dllDir)) { throw 'Intel redist directory not found' }
 
 Copy-Item -Path (Join-Path $dllDir '*.dll') -Destination $distBin -Recurse -Force

--- a/ci/copy_intel_redist.ps1
+++ b/ci/copy_intel_redist.ps1
@@ -1,13 +1,21 @@
 $distBin = Join-Path $pwd 'scripts/installer/dist/bin'
 $root    = if ($Env:ONEAPI_ROOT) { $Env:ONEAPI_ROOT } else { 'C:\Program Files (x86)\Intel\oneAPI' }
 
-$candidates = Get-ChildItem (Join-Path $root 'compiler') -Directory |
-    ForEach-Object {
+# First probe the "latest" compiler redist directory (preferred)
+$dllDirCandidates = @(
+    Join-Path $root 'compiler\latest\windows\redist\intel64_win\compiler'
+    Join-Path $root 'compiler\latest\windows\redist\intel64\compiler'
+)
+
+# Fall back to scanning all compiler versions if none of the preferred paths exist
+if (-not ($dllDirCandidates | Where-Object { Test-Path $_ })) {
+    $dllDirCandidates = Get-ChildItem -Path (Join-Path $root 'compiler') -Directory | ForEach-Object {
         @( Join-Path $_ 'windows\redist\intel64_win\compiler' )
         @( Join-Path $_ 'windows\redist\intel64\compiler'      )
     }
+}
 
-$dllDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+$dllDir = $dllDirCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
 if (-not $dllDir) { throw 'Intel redist directory not found' }
 
 Copy-Item -Path (Join-Path $dllDir '*.dll') -Destination $distBin -Recurse -Force

--- a/scripts/installer/create_installer.py
+++ b/scripts/installer/create_installer.py
@@ -132,30 +132,11 @@ def main():
         if dll.exists():
             copy(dll, dist / 'bin')
 
-    mklroot = os.environ.get("MKLROOT")
-    if mklroot:
-        dll = Path(mklroot) / 'redist' / 'intel64' / 'mkl_rt.dll'
-        if dll.exists():
-            copy(dll, dist / 'bin')
-
     oneapi_root = os.environ.get("ONEAPI_ROOT")
     if oneapi_root:
-        dll_dir = None
-        comp_root = Path(oneapi_root) / 'compiler'
-        if comp_root.exists():
-            for ver in comp_root.iterdir():
-                if not ver.is_dir():
-                    continue
-                for sub in ('windows/redist/intel64_win/compiler',
-                            'windows/redist/intel64/compiler'):
-                    cand = ver / sub
-                    if cand.exists():
-                        dll_dir = cand
-                        break
-                if dll_dir:
-                    break
-        if dll_dir:
-            needed = [
+        bin_dir = Path(oneapi_root) / '2024.1' / 'bin'
+        if bin_dir.exists():
+            dlls = [
                 'libifcoremd.dll',
                 'libifcorert.dll',
                 'libifportmd.dll',
@@ -163,9 +144,10 @@ def main():
                 'libirc.dll',
                 'svml_dispmd.dll',
                 'libiomp5md.dll',
+                'mkl_rt.dll',
             ]
-            for name in needed:
-                src = dll_dir / name
+            for name in dlls:
+                src = bin_dir / name
                 if src.exists():
                     copy(src, dist / 'bin')
 

--- a/scripts/installer/create_installer.py
+++ b/scripts/installer/create_installer.py
@@ -141,60 +141,11 @@ def main():
 
     oneapi_root = os.environ.get("ONEAPI_ROOT")
     if oneapi_root:
-        root = Path(oneapi_root)
-        root_path = None
-        for ver in root.iterdir():
-            win = ver / 'compiler' / 'windows'
-            if win.exists():
-                root_path = win
-                break
-        if root_path is None:
-            fallback = root / 'compiler' / 'latest' / 'windows'
-            if fallback.exists():
-                root_path = fallback
-        if root_path:
-            redist = root_path / 'redist'
-            compiler_lib = root_path.parent / 'lib'
-            for sub in ('intel64_win/compiler', 'intel64/compiler'):
-                omp_dir = redist / sub
-                if not omp_dir.exists():
-                    continue
-                for dll in omp_dir.glob('*.dll'):
-                    if 'debug' not in dll.name.lower():
-                        copy(dll, dist / 'bin')
-
-            # Ensure Fortran runtime libraries are bundled
-            fortran_libs = [
-                'libifcoremd.dll',
-                'libifportmd.dll',
-                'libimf.dll',
-                'libirc.dll',
-                'svml_dispmd.dll',
-                'libdecimal.dll',
-                'libintlc.dll',
-            ]
-            search_dirs = [
-                redist / 'intel64_win' / 'compiler',
-                redist / 'intel64' / 'compiler',
-                compiler_lib / 'intel64_win',
-                compiler_lib / 'intel64',
-                Path(oneapi_root) / 'compiler' / 'latest' / 'redist' / 'intel64_win' / 'compiler',
-                Path(oneapi_root) / 'compiler' / 'latest' / 'redist' / 'intel64' / 'compiler',
-            ]
-            lib_env = os.environ.get('LIB')
-            if lib_env:
-                for path in lib_env.split(';'):
-                    if path:
-                        search_dirs.append(Path(path))
-            for lib_dir in search_dirs:
-                if not lib_dir.exists():
-                    continue
-                log(f"Searching for Fortran DLLs in {lib_dir}")
-                for flib in fortran_libs:
-                    dll = lib_dir / flib
-                    if dll.exists():
-                        log(f"Copying {dll.name} from {lib_dir}")
-                        copy(dll, dist / 'bin')
+        dll_dir = Path(oneapi_root) / '2024.1' / 'bin'
+        if dll_dir.exists():
+            for dll in dll_dir.glob('*.dll'):
+                if 'debug' not in dll.name.lower():
+                    copy(dll, dist / 'bin')
 
     xtb_dir = os.environ.get("XTB_DIR")
     if xtb_dir:

--- a/scripts/installer/create_installer.py
+++ b/scripts/installer/create_installer.py
@@ -141,49 +141,60 @@ def main():
 
     oneapi_root = os.environ.get("ONEAPI_ROOT")
     if oneapi_root:
-        root_path = Path(oneapi_root) / 'compiler' / 'latest' / 'windows'
-        redist = root_path / 'redist'
-        compiler_lib = root_path / 'compiler' / 'lib'
-        for sub in ('intel64_win/compiler', 'intel64/compiler'):
-            omp_dir = redist / sub
-            if not omp_dir.exists():
-                continue
-            for dll in omp_dir.glob('*.dll'):
-                if 'debug' not in dll.name.lower():
-                    copy(dll, dist / 'bin')
+        root = Path(oneapi_root)
+        root_path = None
+        for ver in root.iterdir():
+            win = ver / 'compiler' / 'windows'
+            if win.exists():
+                root_path = win
+                break
+        if root_path is None:
+            fallback = root / 'compiler' / 'latest' / 'windows'
+            if fallback.exists():
+                root_path = fallback
+        if root_path:
+            redist = root_path / 'redist'
+            compiler_lib = root_path.parent / 'lib'
+            for sub in ('intel64_win/compiler', 'intel64/compiler'):
+                omp_dir = redist / sub
+                if not omp_dir.exists():
+                    continue
+                for dll in omp_dir.glob('*.dll'):
+                    if 'debug' not in dll.name.lower():
+                        copy(dll, dist / 'bin')
 
-        # Ensure Fortran runtime libraries are bundled
-        fortran_libs = [
-            'libifcoremd.dll',
-            'libifportmd.dll',
-            'libimf.dll',
-            'libirc.dll',
-            'svml_dispmd.dll',
-            'libdecimal.dll',
-            'libintlc.dll',
-        ]
-        search_dirs = [
-            redist / 'intel64_win' / 'compiler',
-            redist / 'intel64' / 'compiler',
-            Path(oneapi_root) / 'compiler' / 'latest' / 'redist' / 'intel64_win' / 'compiler',
-            Path(oneapi_root) / 'compiler' / 'latest' / 'redist' / 'intel64' / 'compiler',
-            compiler_lib / 'intel64_win',
-            compiler_lib / 'intel64',
-        ]
-        lib_env = os.environ.get('LIB')
-        if lib_env:
-            for path in lib_env.split(';'):
-                if path:
-                    search_dirs.append(Path(path))
-        for lib_dir in search_dirs:
-            if not lib_dir.exists():
-                continue
-            log(f"Searching for Fortran DLLs in {lib_dir}")
-            for flib in fortran_libs:
-                dll = lib_dir / flib
-                if dll.exists():
-                    log(f"Copying {dll.name} from {lib_dir}")
-                    copy(dll, dist / 'bin')
+            # Ensure Fortran runtime libraries are bundled
+            fortran_libs = [
+                'libifcoremd.dll',
+                'libifportmd.dll',
+                'libimf.dll',
+                'libirc.dll',
+                'svml_dispmd.dll',
+                'libdecimal.dll',
+                'libintlc.dll',
+            ]
+            search_dirs = [
+                redist / 'intel64_win' / 'compiler',
+                redist / 'intel64' / 'compiler',
+                compiler_lib / 'intel64_win',
+                compiler_lib / 'intel64',
+                Path(oneapi_root) / 'compiler' / 'latest' / 'redist' / 'intel64_win' / 'compiler',
+                Path(oneapi_root) / 'compiler' / 'latest' / 'redist' / 'intel64' / 'compiler',
+            ]
+            lib_env = os.environ.get('LIB')
+            if lib_env:
+                for path in lib_env.split(';'):
+                    if path:
+                        search_dirs.append(Path(path))
+            for lib_dir in search_dirs:
+                if not lib_dir.exists():
+                    continue
+                log(f"Searching for Fortran DLLs in {lib_dir}")
+                for flib in fortran_libs:
+                    dll = lib_dir / flib
+                    if dll.exists():
+                        log(f"Copying {dll.name} from {lib_dir}")
+                        copy(dll, dist / 'bin')
 
     xtb_dir = os.environ.get("XTB_DIR")
     if xtb_dir:


### PR DESCRIPTION
## Summary
- remove manual OpenBabel build from windows-xtb-installer workflow
- stop passing OpenBabel paths to cmake, letting the project handle it

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON` *(fails: missing Qt5 before installing packages)*
- `sudo xargs -a .github/apt-packages.txt apt-get install -y`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON`
- `cmake --build build -- -j$(nproc)` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6878882bcba883338f13ca8d4d71dc11