### PR TITLE
Fix HiDPI scaling on Qt5 builds

### DIFF
--- a/avogadro/src/main.cpp
+++ b/avogadro/src/main.cpp
@@ -86,6 +86,13 @@ int main(int argc, char *argv[])
     }
 #endif
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+  // Fix issue #112: ensure Qt scales the UI correctly on HiDPI displays
+  // Enable Qt high-DPI attributes before creating the application
+  QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
+
   // set up groups for QSettings
   QCoreApplication::setOrganizationName("SourceForge");
   QCoreApplication::setOrganizationDomain("sourceforge.net");

--- a/avogadro/src/windows/avogadro.exe.manifest
+++ b/avogadro/src/windows/avogadro.exe.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware>true</dpiAware>
+      <dpiAwareness>PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/avogadro/src/windows/avogadro.rc
+++ b/avogadro/src/windows/avogadro.rc
@@ -1,1 +1,2 @@
 IDI_ICON1               ICON                    "..\\icons\\avogadro.ico"
+1 24 "avogadro.exe.manifest"

--- a/libavogadro/src/glwidget.cpp
+++ b/libavogadro/src/glwidget.cpp
@@ -645,7 +645,13 @@ namespace Avogadro {
 
   void GLWidget::resizeGL( int width, int height )
   {
-    glViewport( 0, 0, width, height );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    const qreal dpr = devicePixelRatioF();
+    glViewport(0, 0, static_cast<int>(width * dpr),
+               static_cast<int>(height * dpr));
+#else
+    glViewport(0, 0, width, height);
+#endif
   }
 
   void GLWidget::setBackground( const QColor &background )


### PR DESCRIPTION
## Summary
- enable Qt high DPI scaling and pixmaps when using Qt5
- embed a Windows manifest declaring PerMonitorV2 DPI awareness
- scale OpenGL viewport by devicePixelRatioF for HiDPI displays

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON`
- `cmake --build build -- -j$(nproc)` *(fails: manual interrupt)*
- `ctest --test-dir build --output-on-failure` *(fails: executables not found)*


------
https://chatgpt.com/codex/tasks/task_e_6881d32d32fc8333871c746686164baa