### PR TITLE
Fix atom dragging distance

### DIFF
--- a/libavogadro/src/tools/autoopttool.cpp
+++ b/libavogadro/src/tools/autoopttool.cpp
@@ -135,8 +135,7 @@ namespace Avogadro {
                                              QMouseEvent *event)
   {
     m_glwidget = widget;
-    qreal dpr = widget->devicePixelRatioF();
-    m_lastDraggingPosition = event->pos() * dpr;
+    m_lastDraggingPosition = event->pos();
 
     m_leftButtonPressed = (event->buttons() & Qt::LeftButton
         && event->modifiers() == Qt::NoModifier);
@@ -151,7 +150,7 @@ namespace Avogadro {
          (event->modifiers() == Qt::ControlModifier ||
           event->modifiers() == Qt::MetaModifier)));
 
-    m_clickedAtom = widget->computeClickedAtom(event->pos() * dpr);
+    m_clickedAtom = widget->computeClickedAtom(event->pos());
     if(m_clickedAtom != 0 && m_leftButtonPressed && m_running)
     {
       event->accept();
@@ -203,15 +202,14 @@ namespace Avogadro {
       if (m_leftButtonPressed) {
         event->accept();
         // translate the molecule following mouse movement
-        qreal dpr = widget->devicePixelRatioF();
         Vector3d begin = widget->camera()->project(*m_clickedAtom->pos());
         QPoint point = QPoint(begin.x(), begin.y());
         translate(widget, *m_clickedAtom->pos(),
-                  point/*m_lastDraggingPosition*/, event->pos() * dpr);
+                  point/*m_lastDraggingPosition*/, event->pos());
       }
     }
 
-    m_lastDraggingPosition = event->pos() * widget->devicePixelRatioF();
+    m_lastDraggingPosition = event->pos();
     widget->update();
 
     return 0;

--- a/libavogadro/src/tools/selectrotatetool.cpp
+++ b/libavogadro/src/tools/selectrotatetool.cpp
@@ -117,16 +117,14 @@ namespace Avogadro {
   {
     m_movedSinceButtonPressed = false;
     m_doubleClick = false; // set true if we get a doubleClick event
-    qreal dpr = widget->devicePixelRatioF();
-    m_lastDraggingPosition = event->pos() * dpr;
-    m_initialDraggingPosition = event->pos() * dpr;
+    m_lastDraggingPosition = event->pos();
+    m_initialDraggingPosition = event->pos();
 
     m_widget = widget; // save for defining centroids
 
     //! List of hits from a selection/pick
-    QPoint scaledPos = event->pos() * dpr;
-    m_hits = widget->hits(scaledPos.x()-SEL_BOX_HALF_SIZE,
-        scaledPos.y()-SEL_BOX_HALF_SIZE,
+    m_hits = widget->hits(event->pos().x()-SEL_BOX_HALF_SIZE,
+        event->pos().y()-SEL_BOX_HALF_SIZE,
         SEL_BOX_SIZE, SEL_BOX_SIZE);
 
     if (event->buttons() & Qt::LeftButton && !m_hits.size()) {
@@ -398,18 +396,14 @@ namespace Avogadro {
     if (m_leftButtonPressed && !m_hits.size()) {
       event->accept();
 
-      qreal dpr = widget->devicePixelRatioF();
-      QPoint scaledPos = event->pos() * dpr;
-      if( ( scaledPos - m_initialDraggingPosition ).manhattanLength() > 2 )
+      if( ( event->pos() - m_initialDraggingPosition ).manhattanLength() > 2 )
         m_movedSinceButtonPressed = true;
 
-      m_lastDraggingPosition = scaledPos;
+      m_lastDraggingPosition = event->pos();
       widget->update();
     }
     else /*if (m_leftButtonPressed)*/ {
-      qreal dpr = widget->devicePixelRatioF();
-      QPoint scaledPos = event->pos() * dpr;
-      if((scaledPos - m_initialDraggingPosition).manhattanLength() > 2)
+      if((event->pos() - m_initialDraggingPosition).manhattanLength() > 2)
         m_movedSinceButtonPressed = true;
       else
         event->accept();


### PR DESCRIPTION
## Summary
- remove unnecessary device pixel ratio scaling in AutoOptTool and SelectRotateTool

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON` *(fails: missing Qt5)*
- `cmake --build build -- -j$(nproc)` *(failed to complete due to build interruption)*

------
https://chatgpt.com/codex/tasks/task_e_68824ce9a3bc8333a8293aa0cab2d5a9