### PR TITLE
Forward OpenBabel override paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,11 +255,12 @@ pass_ob_arg(maeparser_LIBRARIES)
 pass_ob_arg(coordgen_DIR)
 pass_ob_arg(coordgen_INCLUDE_DIRS)
 pass_ob_arg(coordgen_LIBRARIES)
-pass_ob_arg(LIBXML2_LIBRARY)
+pass_ob_arg(LIBXML2_LIBRARIES)
 pass_ob_arg(LIBXML2_INCLUDE_DIR)
 pass_ob_arg(ZLIB_LIBRARY)
 pass_ob_arg(ZLIB_INCLUDE_DIR)
 pass_ob_arg(wxWidgets_LIB_DIR)
+pass_ob_arg(LIB_INSTALL_DIR)
 ExternalProject_Add(openbabel_ext
   URL https://github.com/thosoo/openbabel/archive/052ba3dab10a8c59a9d821e04b2faba24e104c72.zip
   URL_HASH SHA256=26144b05b4f47dc3e78a7474b4789a5fe4049f4289a5aaed4a0a00689f123ad4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,29 @@ set(I18N_LANGUAGE "" CACHE STRING "Build i18n only for selected language")
 set(OPENBABEL_INSTALL_DIR "${CMAKE_BINARY_DIR}/openbabel-install")
 file(MAKE_DIRECTORY "${OPENBABEL_INSTALL_DIR}/include/openbabel3")
 file(MAKE_DIRECTORY "${OPENBABEL_INSTALL_DIR}/bin")
+set(OB_OVERRIDE_ARGS "")
+macro(pass_ob_arg var)
+  if(DEFINED ${var})
+    list(APPEND OB_OVERRIDE_ARGS -D${var}=${${var}})
+  endif()
+endmacro()
+pass_ob_arg(EIGEN3_INCLUDE_DIR)
+pass_ob_arg(INCHI_INCLUDE_DIR)
+pass_ob_arg(INCHI_LIBRARY)
+pass_ob_arg(CAIRO_INCLUDE_DIRS)
+pass_ob_arg(CAIRO_LIBRARIES)
+pass_ob_arg(RAPIDJSON_INCLUDE_DIRS)
+pass_ob_arg(MAEPARSER_DIR)
+pass_ob_arg(maeparser_INCLUDE_DIRS)
+pass_ob_arg(maeparser_LIBRARIES)
+pass_ob_arg(coordgen_DIR)
+pass_ob_arg(coordgen_INCLUDE_DIRS)
+pass_ob_arg(coordgen_LIBRARIES)
+pass_ob_arg(LIBXML2_LIBRARY)
+pass_ob_arg(LIBXML2_INCLUDE_DIR)
+pass_ob_arg(ZLIB_LIBRARY)
+pass_ob_arg(ZLIB_INCLUDE_DIR)
+pass_ob_arg(wxWidgets_LIB_DIR)
 ExternalProject_Add(openbabel_ext
   URL https://github.com/thosoo/openbabel/archive/052ba3dab10a8c59a9d821e04b2faba24e104c72.zip
   URL_HASH SHA256=26144b05b4f47dc3e78a7474b4789a5fe4049f4289a5aaed4a0a00689f123ad4
@@ -251,6 +274,7 @@ ExternalProject_Add(openbabel_ext
     -DOB_USE_PREBUILT_BINARIES=OFF
     -DOPENBABEL_USE_SYSTEM_INCHI=OFF
     -DWITH_INCHI=ON
+    ${OB_OVERRIDE_ARGS}
   UPDATE_COMMAND ""
 )
 if(WIN32)

--- a/INSTALL
+++ b/INSTALL
@@ -60,9 +60,10 @@ installation locations.
      RAPIDJSON_INCLUDE_DIRS
      MAEPARSER_DIR (with maeparser_INCLUDE_DIRS/maeparser_LIBRARIES)
      coordgen_DIR (with coordgen_INCLUDE_DIRS/coordgen_LIBRARIES)
-     LIBXML2_INCLUDE_DIR / LIBXML2_LIBRARY
-     ZLIB_INCLUDE_DIR / ZLIB_LIBRARY
-     wxWidgets_LIB_DIR
+    LIBXML2_INCLUDE_DIR / LIBXML2_LIBRARIES
+    ZLIB_INCLUDE_DIR / ZLIB_LIBRARY
+    wxWidgets_LIB_DIR
+    LIB_INSTALL_DIR
 
    -DENABLE_PYTHON : specify whether to build Boost.Python interpreter
                     (default = TRUE)
@@ -77,3 +78,5 @@ is installed to the location specified at compile time none of these variables
 need to be set.
 
 AVOGADRO_TRANSLATIONS - the location of the translation files.
+BABEL_LIBDIR - the location of Open Babel format plugins
+BABEL_DATADIR - the location of Open Babel data files

--- a/INSTALL
+++ b/INSTALL
@@ -50,7 +50,19 @@ installation locations.
 
    -DOPENBABEL2_INCLUDE_DIR : specify the OpenBabel2 include directory (optional)
 
-   -DEIGEN3_INCLUDE_DIR : specify the Eigen include directory
+   -DEIGEN3_INCLUDE_DIR : specify the Eigen include directory (also forwarded
+                          to the bundled Open Babel build)
+
+   The following variables are also passed to the bundled Open Babel build when
+   defined. They allow overriding dependency locations:
+     INCHI_INCLUDE_DIR / INCHI_LIBRARY
+     CAIRO_INCLUDE_DIRS / CAIRO_LIBRARIES
+     RAPIDJSON_INCLUDE_DIRS
+     MAEPARSER_DIR (with maeparser_INCLUDE_DIRS/maeparser_LIBRARIES)
+     coordgen_DIR (with coordgen_INCLUDE_DIRS/coordgen_LIBRARIES)
+     LIBXML2_INCLUDE_DIR / LIBXML2_LIBRARY
+     ZLIB_INCLUDE_DIR / ZLIB_LIBRARY
+     wxWidgets_LIB_DIR
 
    -DENABLE_PYTHON : specify whether to build Boost.Python interpreter
                     (default = TRUE)


### PR DESCRIPTION
## Summary
- forward environment overrides for dependencies from Avogadro into the
  bundled Open Babel build via `OB_OVERRIDE_ARGS`
- document the forwarded variables in the INSTALL guide

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON`
- `cmake --build build -- -j$(nproc)` *(fails: build interrupted)*
- `ctest --test-dir build --output-on-failure` *(fails: executables not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883e2d8e2d083339ec8e9f2c084443b