### PR TITLE
Bundle Open Babel data files and set paths in installer

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -151,6 +151,11 @@ jobs:
         run: |
           $env:PATH = "$PWD\build\openbabel-install\bin;$env:PATH"
           ctest --test-dir build -C Release --output-on-failure
+      - name: Verify Open Babel CIF support
+        if: matrix.target == 'tests'
+        shell: pwsh
+        run: |
+          & "$PWD\build\openbabel-install\bin\obabel.exe" crystals/other/C10H10Fe-Ferrocene.cif -oinchi > $null
       - name: Upload installer
         if: matrix.target == 'installer'
         uses: actions/upload-artifact@v4

--- a/scripts/installer/create_installer.py
+++ b/scripts/installer/create_installer.py
@@ -37,6 +37,7 @@ def main():
     ob_bindir = os.environ.get("OPENBABEL_BINDIR")
     if ob_bindir and ob_dir is None:
         ob_dir = Path(ob_bindir).parent
+    ob_version = None
     if ob_dir:
         ob = ob_dir
 
@@ -90,22 +91,11 @@ def main():
 
         share = ob / "share" / "openbabel" / ob_version
         alt_share = ob / "bin" / "data"
-        if not share.exists() and alt_share.exists():
-            share = alt_share
-        if share.exists():
+        src_share = share if share.exists() else alt_share if alt_share.exists() else None
+        if src_share:
             dest = dist / "share" / "openbabel" / ob_version
-            log(f"Copying OpenBabel data from {share} to {dest}")
-            shutil.copytree(share, dest, dirs_exist_ok=True)
-            patterns = ["*.txt", "*.par", "*.prm", "*.ff", "*.dat"]
-            for pat in patterns:
-                for f in share.glob(pat):
-                    if f.is_file():
-                        copy(f, dist / "bin")
-        if alt_share.exists():
-            for pat in ["*.txt", "*.par", "*.prm", "*.ff", "*.dat"]:
-                for f in alt_share.glob(pat):
-                    if f.is_file():
-                        copy(f, dist / "bin")
+            log(f"Copying OpenBabel data from {src_share} to {dest}")
+            shutil.copytree(src_share, dest, dirs_exist_ok=True)
 
     libxml = os.environ.get("LIBXML2_LIBRARY")
     if libxml:
@@ -154,6 +144,8 @@ def main():
         args.append(f"/DVERSION={version}")
     if vi_version:
         args.append(f"/DVI_VERSION={vi_version}")
+    if ob_version:
+        args.append(f"/DOB_VERSION={ob_version}")
     args.append(str(root / "setup.nsi"))
     log("Running makensis")
     subprocess.check_call(args)

--- a/scripts/installer/setup.nsi
+++ b/scripts/installer/setup.nsi
@@ -26,6 +26,9 @@ ManifestDPIAware true
 !ifndef VERSION
 !define VERSION "1.1.0"
 !endif
+!ifndef OB_VERSION
+!define OB_VERSION "2"
+!endif
 VIProductVersion "${VI_VERSION}" # file version for the installer in the scheme "x.x.x.x"
 Name "Avogadro"
 !define REGKEY "SOFTWARE\Avogadro"
@@ -46,6 +49,8 @@ Name "Avogadro"
 # registry preparations
 !define SHCNE_ASSOCCHANGED 0x08000000
 !define SHCNF_IDLIST 0
+!define HWND_BROADCAST 0xFFFF
+!define WM_SETTINGCHANGE 0x001A
 
 
 # Variables
@@ -259,6 +264,13 @@ Section "-Installation actions" SecInstallation
   # register Avogadro
   WriteRegStr SHCTX "${REGKEY}" Path $INSTDIR
   WriteUninstaller $INSTDIR\uninstall.exe
+
+  # Set Open Babel environment variables
+  WriteRegExpandStr SHCTX "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment" "BABEL_DATADIR" "$INSTDIR\\share\\openbabel\\${OB_VERSION}"
+  WriteRegExpandStr SHCTX "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment" "BABEL_LIBDIR" "$INSTDIR\\bin"
+  System::Call 'Kernel32::SetEnvironmentVariableW(w "BABEL_DATADIR", w "$INSTDIR\\share\\openbabel\\${OB_VERSION}")'
+  System::Call 'Kernel32::SetEnvironmentVariableW(w "BABEL_LIBDIR", w "$INSTDIR\\bin")'
+  System::Call 'Kernel32::SendMessageTimeoutW(i ${HWND_BROADCAST}, i ${WM_SETTINGCHANGE}, i 0, w "Environment", i 0, i 5000, *i .r0)'
   
   # create shortcuts to startmenu
   # ensure the working directory is the binary path so avogadro.dll resolves


### PR DESCRIPTION
## Summary
- copy the full Open Babel data tree into the Windows installer
- set `BABEL_DATADIR` and `BABEL_LIBDIR` during installation so Open Babel can locate its resources
- verify CIF parsing in the Windows installer workflow

## Testing
- `python -m py_compile scripts/installer/create_installer.py`


------
https://chatgpt.com/codex/tasks/task_e_689da5056a78833390364e029861bc6f