### PR TITLE
Spectra: add X-axis unit conversion, advanced broadening models, and data-table/display unit handling

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -65,15 +65,28 @@ jobs:
           $zlibDir = Join-Path $bld "install"
           $inc = Join-Path $zlibDir "include"
           $libDir = Join-Path $zlibDir "lib"
-          $static = Join-Path $libDir "zlibstatic.lib"
-          if (-not (Test-Path $static)) {
-            # zlib 1.3.2+ CMake installs the static library as zs.lib
-            $static = Join-Path $libDir "zs.lib"
+          $libCandidates = @(
+            (Join-Path $libDir "zlibstatic.lib"),
+            (Join-Path $libDir "zs.lib")
+          )
+          # Optional fallback: any obvious static zlib lib, excluding shared/import aliases.
+          $extraStatic = Get-ChildItem -Path $libDir -Filter "*.lib" -ErrorAction SilentlyContinue |
+            Where-Object {
+              $_.Name -match '^(zlib.*|zs)\.lib$' -and
+              $_.Name -notin @('z.lib', 'zlib.lib')
+            } |
+            Select-Object -ExpandProperty FullName
+          if ($extraStatic) {
+            $libCandidates += $extraStatic
           }
+          $static = $libCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
           $lib = Join-Path $libDir "zlib.lib"
           if (-not (Test-Path $static)) {
-            throw "Could not find zlib static library (tried zlibstatic.lib and zs.lib)"
+            Write-Host "Installed zlib lib directory contents:"
+            Get-ChildItem $libDir | Format-Table -AutoSize | Out-String | Write-Host
+            throw "Could not find a static zlib library. Tried: $($libCandidates -join ', ')"
           }
+          Write-Host "Using zlib static library: $static"
           Copy-Item $static $lib -Force
           "CMAKE_PREFIX_PATH=$zlibDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_INCLUDE_PATH=$inc;$env:CMAKE_INCLUDE_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build zlib
         shell: pwsh
         run: |
-          $ver = '1.3.1'
+          $ver = '1.3.2'
           $zip = "$env:RUNNER_TEMP\zlib.zip"
           $zlibArchive = "zlib$($ver -replace '\.', '').zip"
           $urls = @(

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -66,7 +66,14 @@ jobs:
           $inc = Join-Path $zlibDir "include"
           $libDir = Join-Path $zlibDir "lib"
           $static = Join-Path $libDir "zlibstatic.lib"
+          if (-not (Test-Path $static)) {
+            # zlib 1.3.2+ CMake installs the static library as zs.lib
+            $static = Join-Path $libDir "zs.lib"
+          }
           $lib = Join-Path $libDir "zlib.lib"
+          if (-not (Test-Path $static)) {
+            throw "Could not find zlib static library (tried zlibstatic.lib and zs.lib)"
+          }
           Copy-Item $static $lib -Force
           "CMAKE_PREFIX_PATH=$zlibDir;$env:CMAKE_PREFIX_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_INCLUDE_PATH=$inc;$env:CMAKE_INCLUDE_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/libavogadro/src/extensions/spectra/abstract_ir.cpp
+++ b/libavogadro/src/extensions/spectra/abstract_ir.cpp
@@ -241,6 +241,7 @@ namespace Avogadro {
     }
     m_xAxisUnit = unit;
     updatePlotLabels();
+    m_dialog->regenerateImportedSpectra();
     emit plotDataChanged();
   }
 
@@ -542,7 +543,7 @@ namespace Avogadro {
     }
   }
 
-  double AbstractIRSpectra::scale(double w)
+  double AbstractIRSpectra::scale(double w) const
   {
     switch(m_scalingType) {
       case LINEAR:

--- a/libavogadro/src/extensions/spectra/abstract_ir.cpp
+++ b/libavogadro/src/extensions/spectra/abstract_ir.cpp
@@ -22,10 +22,17 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
+#include <QtGlobal>
 
 using namespace std;
 
 namespace Avogadro {
+  namespace {
+    const double kMinDenominator = 1.0e-12;
+    const double kMinPositiveWavenumber = 1.0e-8;
+  }
+
   AbstractIRSpectra::AbstractIRSpectra( SpectraDialog *parent ) :
     SpectraType( parent ), m_scale(0.0), m_fwhm(0.0), m_labelYThreshold(0.0),
     m_scalingType(LINEAR), m_broadeningModel(CONSTANT_WIDTH),
@@ -102,11 +109,17 @@ namespace Avogadro {
           maxWavenumber = m_xList.at(i);
         }
       }
-      plotObject->addPoint(minWavenumber, 0);
+      if (std::isfinite(minWavenumber)) {
+        plotObject->addPoint(minWavenumber, 0);
+      }
 
       for (int i = 0; i < m_yList.size(); i++) {
         double wavenumber = m_xList.at(i);// already scaled!
         double transmittance = m_yList.at(i);
+        if (!std::isfinite(wavenumber) || !std::isfinite(transmittance) ||
+            !isNativeXValidForCurrentAxis(wavenumber)) {
+          continue;
+        }
         plotObject->addPoint ( wavenumber, 0 );
         if (ui.cb_labelPeaks->isChecked()) {
           // %L1 uses localized number format (e.g., 1.023,4 in Europe)
@@ -117,7 +130,9 @@ namespace Avogadro {
         }
         plotObject->addPoint( wavenumber, 0 );
       }
-      plotObject->addPoint(maxWavenumber, 0);
+      if (std::isfinite(maxWavenumber)) {
+        plotObject->addPoint(maxWavenumber, 0);
+      }
     } // End singlets
 
     else { // Get broadened peaks in native wavenumber / shift space
@@ -128,20 +143,37 @@ namespace Avogadro {
       if (plotObject->points().isEmpty()) {
         return;
       }
-      min = max = plotObject->points().first()->y();
+      bool haveFinite = false;
+      min = std::numeric_limits<double>::infinity();
+      max = -std::numeric_limits<double>::infinity();
       for(int i = 0; i< plotObject->points().size(); i++) {
         double cur = plotObject->points().at(i)->y();
+        if (!std::isfinite(cur)) {
+          continue;
+        }
         if (cur < min) min = cur;
         if (cur > max) max = cur;
+        haveFinite = true;
       }
-      if (max <= min) {
+      if (!haveFinite || !std::isfinite(min) || !std::isfinite(max) ||
+          !(max > min) || !std::isfinite(max - min)) {
         for(int i = 0; i< plotObject->points().size(); i++) {
           plotObject->points().at(i)->setY(0.0);
         }
       } else {
+        const double range = max - min;
         for(int i = 0; i< plotObject->points().size(); i++) {
           double cur = plotObject->points().at(i)->y();
-          plotObject->points().at(i)->setY( (cur - min) * 100 / (max - min));
+          if (!std::isfinite(cur)) {
+            plotObject->points().at(i)->setY(0.0);
+            continue;
+          }
+          const double normalized = (cur - min) * 100.0 / range;
+          if (!std::isfinite(normalized)) {
+            plotObject->points().at(i)->setY(0.0);
+            continue;
+          }
+          plotObject->points().at(i)->setY(normalized);
         }
       }
     } // End gaussians
@@ -398,14 +430,17 @@ namespace Avogadro {
 
   double AbstractIRSpectra::displayedXFromWavenumber(double scaledWavenumber) const
   {
+    if (!std::isfinite(scaledWavenumber)) {
+      return 0.0;
+    }
     switch (m_xAxisUnit) {
       case WAVELENGTH_UM:
-        if (scaledWavenumber == 0.0) {
+        if (std::abs(scaledWavenumber) < kMinDenominator) {
           return 0.0;
         }
         return 1.0e4 / scaledWavenumber;
       case WAVELENGTH_NM:
-        if (scaledWavenumber == 0.0) {
+        if (std::abs(scaledWavenumber) < kMinDenominator) {
           return 0.0;
         }
         return 1.0e7 / scaledWavenumber;
@@ -421,11 +456,35 @@ namespace Avogadro {
 
   void AbstractIRSpectra::convertPlotObjectXToDisplayUnits(PlotObject *plotObject) const
   {
+    QList<double> xValues;
+    QList<double> yValues;
+    QStringList labels;
     for (int i = 0; i < plotObject->points().size(); ++i) {
       PlotPoint *point = plotObject->points().at(i);
-      point->setX(displayedXFromWavenumber(point->x()));
+      const double nativeX = point->x();
+      const double y = point->y();
+      if (!std::isfinite(nativeX) || !std::isfinite(y) ||
+          !isNativeXValidForCurrentAxis(nativeX)) {
+        continue;
+      }
+      const double displayX = displayedXFromWavenumber(nativeX);
+      if (!std::isfinite(displayX)) {
+        continue;
+      }
+      xValues.append(displayX);
+      yValues.append(y);
       if (!point->label().isEmpty()) {
-        point->setLabel(QString("%L1").arg(point->x(), 0, 'f', 1));
+        labels.append(QString("%L1").arg(displayX, 0, 'f', 1));
+      } else {
+        labels.append(QString());
+      }
+    }
+    plotObject->clearPoints();
+    for (int i = 0; i < xValues.size(); ++i) {
+      if (labels.at(i).isEmpty()) {
+        plotObject->addPoint(xValues.at(i), yValues.at(i));
+      } else {
+        plotObject->addPoint(xValues.at(i), yValues.at(i), labels.at(i));
       }
     }
   }
@@ -455,6 +514,32 @@ namespace Avogadro {
     } else {
       xMin = highDisplay;
       xMax = lowDisplay;
+    }
+  }
+
+  void AbstractIRSpectra::nativeXBounds(double &xMin, double &xMax) const
+  {
+    xMin = -std::numeric_limits<double>::infinity();
+    xMax = std::numeric_limits<double>::infinity();
+    if (m_xAxisUnit == WAVELENGTH_UM || m_xAxisUnit == WAVELENGTH_NM) {
+      xMin = kMinPositiveWavenumber;
+    }
+  }
+
+  bool AbstractIRSpectra::isNativeXValidForCurrentAxis(double x) const
+  {
+    if (!std::isfinite(x)) {
+      return false;
+    }
+    switch (m_xAxisUnit) {
+      case WAVELENGTH_UM:
+      case WAVELENGTH_NM:
+        return x > kMinPositiveWavenumber;
+      case ENERGY_MEV:
+      case ENERGY_KJMOL:
+      case WAVENUMBER_CM1:
+      default:
+        return true;
     }
   }
 
@@ -512,34 +597,92 @@ namespace Avogadro {
     }
 
     QList<double> xPoints = getXPoints(maxFwhm, m_nPoints);
+    double nativeMin = 0.0, nativeMax = 0.0;
+    nativeXBounds(nativeMin, nativeMax);
+    const bool useMinBound = std::isfinite(nativeMin);
+    const bool useMaxBound = std::isfinite(nativeMax);
     for (int i = 0; i < xPoints.size(); ++i) {
       double x = xPoints.at(i);
+      if (!std::isfinite(x)) {
+        continue;
+      }
+      if (useMinBound && x < nativeMin) {
+        continue;
+      }
+      if (useMaxBound && x > nativeMax) {
+        continue;
+      }
+      if (!isNativeXValidForCurrentAxis(x)) {
+        continue;
+      }
       double y = 0.0;
+      bool yValid = true;
       for (int j = 0; j < m_yList.size(); ++j) {
         const double center = m_xList.at(j);
         const double intensity = m_yList.at(j);
+        if (!std::isfinite(center) || !std::isfinite(intensity)) {
+          continue;
+        }
         const double fwhm = std::max(0.01, modeledFwhm(center));
+        if (!std::isfinite(fwhm)) {
+          continue;
+        }
         const double gaussianSigma = fwhm / (2.0 * sqrt(2.0 * log(2.0)));
+        if (!std::isfinite(gaussianSigma) || gaussianSigma <= kMinDenominator) {
+          continue;
+        }
         // Use area-normalized kernels for all shapes so width changes are
         // consistent across Gaussian/Lorentzian/Pseudo-Voigt models.
         static const double kPi = 3.14159265358979323846;
+        const double delta = x - center;
+        const double exponent = -((delta * delta) /
+                                  (2.0 * gaussianSigma * gaussianSigma));
         const double gaussian = (1.0 / (gaussianSigma * sqrt(2.0 * kPi))) *
-          exp(-(pow(x - center, 2.0)) / (2.0 * gaussianSigma * gaussianSigma));
+          exp(exponent);
         const double hwhm = fwhm * 0.5;
+        if (!std::isfinite(hwhm) || hwhm <= kMinDenominator) {
+          continue;
+        }
+        const double lorentzDenominator = (delta * delta + hwhm * hwhm);
+        if (!std::isfinite(lorentzDenominator) ||
+            lorentzDenominator <= kMinDenominator) {
+          continue;
+        }
         const double lorentz =
-          hwhm / (kPi * ((x - center) * (x - center) + hwhm * hwhm));
+          hwhm / (kPi * lorentzDenominator);
+        if (!std::isfinite(gaussian) || !std::isfinite(lorentz)) {
+          continue;
+        }
 
+        double contribution = 0.0;
         if (m_lineShape == LORENTZIAN) {
-          y += intensity * lorentz;
+          contribution = intensity * lorentz;
         } else if (m_lineShape == VOIGT) {
           // Pseudo-Voigt approximation: linear mix of normalized Gaussian and
           // Lorentzian kernels (not a full Voigt convolution).
-          y += intensity * (m_voigtMix * lorentz + (1.0 - m_voigtMix) * gaussian);
+          contribution = intensity * (m_voigtMix * lorentz +
+            (1.0 - m_voigtMix) * gaussian);
         } else {
-          y += intensity * gaussian;
+          contribution = intensity * gaussian;
+        }
+        if (!std::isfinite(contribution)) {
+          yValid = false;
+          break;
+        }
+        y += contribution;
+        if (!std::isfinite(y)) {
+          yValid = false;
+          break;
         }
       }
+      if (!yValid || !std::isfinite(y)) {
+        continue;
+      }
       plotObject->addPoint(x, y);
+#ifndef NDEBUG
+      Q_ASSERT(std::isfinite(x));
+      Q_ASSERT(std::isfinite(y));
+#endif
     }
   }
 

--- a/libavogadro/src/extensions/spectra/abstract_ir.cpp
+++ b/libavogadro/src/extensions/spectra/abstract_ir.cpp
@@ -20,12 +20,18 @@
 
 #include "abstract_ir.h"
 
+#include <algorithm>
+#include <cmath>
+
 using namespace std;
 
 namespace Avogadro {
   AbstractIRSpectra::AbstractIRSpectra( SpectraDialog *parent ) :
     SpectraType( parent ), m_scale(0.0), m_fwhm(0.0), m_labelYThreshold(0.0),
-    m_lineShape(GAUSSIAN), m_nPoints(10)
+    m_scalingType(LINEAR), m_broadeningModel(CONSTANT_WIDTH),
+    m_xAxisUnit(WAVENUMBER_CM1), m_lineShape(GAUSSIAN), m_nPoints(10),
+    m_temperature(298.15), m_referenceTemperature(298.15), m_modelExponent(1.0),
+    m_baselineWidth(0.0), m_anharmonicAmplitude(0.0), m_voigtMix(0.5)
     {
     ui.setupUi(m_tab_widget);
 
@@ -56,17 +62,47 @@ namespace Avogadro {
             this, SIGNAL(plotDataChanged()));
     connect(ui.combo_yaxis, SIGNAL(currentIndexChanged(QString)),
             this, SLOT(updateYAxis(QString)));
+    connect(ui.combo_xaxis, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(updateXAxis(int)));
     connect(ui.combo_scalingType, SIGNAL(currentIndexChanged(int)),
             this, SLOT(changeScalingType(int)));
     connect(ui.combo_lineShape, SIGNAL(currentIndexChanged(int)),
             this, SLOT(changeLineShape(int)));
+    connect(ui.combo_broadeningModel, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(changeBroadeningModel(int)));
+    connect(ui.spin_temperature, SIGNAL(valueChanged(double)),
+            this, SLOT(updateTemperature(double)));
+    connect(ui.spin_referenceTemperature, SIGNAL(valueChanged(double)),
+            this, SLOT(updateReferenceTemperature(double)));
+    connect(ui.spin_modelExponent, SIGNAL(valueChanged(double)),
+            this, SLOT(updateModelExponent(double)));
+    connect(ui.spin_zeroWidth, SIGNAL(valueChanged(double)),
+            this, SLOT(updateBaselineWidth(double)));
+    connect(ui.spin_anharmonicAmplitude, SIGNAL(valueChanged(double)),
+            this, SLOT(updateAnharmonicAmplitude(double)));
+    connect(ui.spin_voigtMix, SIGNAL(valueChanged(double)),
+            this, SLOT(updateVoigtMix(double)));
+    updateBroadeningControls();
   }
 
   void AbstractIRSpectra::getCalculatedPlotObject(PlotObject *plotObject) {
     plotObject->clearPoints();
 
-    if (m_fwhm == 0.0) { // get singlets
-      plotObject->addPoint( 400, 0);
+    if (!hasEffectiveBroadening()) { // get singlets
+      if (m_xList.isEmpty()) {
+        return;
+      }
+      double minWavenumber = m_xList.at(0);
+      double maxWavenumber = m_xList.at(0);
+      for (int i = 1; i < m_xList.size(); ++i) {
+        if (m_xList.at(i) < minWavenumber) {
+          minWavenumber = m_xList.at(i);
+        }
+        if (m_xList.at(i) > maxWavenumber) {
+          maxWavenumber = m_xList.at(i);
+        }
+      }
+      plotObject->addPoint(minWavenumber, 0);
 
       for (int i = 0; i < m_yList.size(); i++) {
         double wavenumber = m_xList.at(i);// already scaled!
@@ -81,35 +117,42 @@ namespace Avogadro {
         }
         plotObject->addPoint( wavenumber, 0 );
       }
-      plotObject->addPoint( 3500, 0);
+      plotObject->addPoint(maxWavenumber, 0);
     } // End singlets
 
-    else { // Get gaussians
+    else { // Get broadened peaks in native wavenumber / shift space
         m_nPoints = ui.spin_nPoints->value();
-        if (m_lineShape == GAUSSIAN) {
-            gaussianWiden(plotObject, m_fwhm, m_nPoints);
-        } else {
-            lorentzianWiden (plotObject, m_fwhm, m_nPoints);
-        }
+        addBroadenedPeaks(plotObject);
       // Normalization is probably screwed up, so renormalize the data
       double min, max;
+      if (plotObject->points().isEmpty()) {
+        return;
+      }
       min = max = plotObject->points().first()->y();
       for(int i = 0; i< plotObject->points().size(); i++) {
         double cur = plotObject->points().at(i)->y();
         if (cur < min) min = cur;
         if (cur > max) max = cur;
       }
-      for(int i = 0; i< plotObject->points().size(); i++) {
-        double cur = plotObject->points().at(i)->y();
-        plotObject->points().at(i)->setY( (cur - min) * 100 / (max - min));
+      if (max <= min) {
+        for(int i = 0; i< plotObject->points().size(); i++) {
+          plotObject->points().at(i)->setY(0.0);
+        }
+      } else {
+        for(int i = 0; i< plotObject->points().size(); i++) {
+          double cur = plotObject->points().at(i)->y();
+          plotObject->points().at(i)->setY( (cur - min) * 100 / (max - min));
+        }
       }
     } // End gaussians
+
+    convertPlotObjectXToDisplayUnits(plotObject);
   }
 
   void AbstractIRSpectra::rescaleFrequencies()
   {
     for (int i=0; i<m_xList_orig.size(); i++) {
-      m_xList[i] = m_xList_orig.at(i) * scale(m_xList.at(i));
+      m_xList[i] = scaledWavenumber(m_xList_orig.at(i));
     }
     emit plotDataChanged();
   }
@@ -182,8 +225,22 @@ namespace Avogadro {
     if (m_yaxis == text) {
       return;
     }
-    m_dialog->getUi()->plot->axis(PlotWidget::LeftAxis)->setLabel(text);
     m_yaxis = text;
+    updatePlotLabels();
+    emit plotDataChanged();
+  }
+
+  void AbstractIRSpectra::updateXAxis(int index)
+  {
+    if (index < 0 || index >= ui.combo_xaxis->count()) {
+      return;
+    }
+    XAxisUnit unit = static_cast<XAxisUnit>(index);
+    if (m_xAxisUnit == unit) {
+      return;
+    }
+    m_xAxisUnit = unit;
+    updatePlotLabels();
     emit plotDataChanged();
   }
 
@@ -195,6 +252,14 @@ namespace Avogadro {
   void AbstractIRSpectra::changeLineShape(int type)
   {
     m_lineShape = static_cast<LineShape>(type);
+    updateBroadeningControls();
+    emit plotDataChanged();
+  }
+
+  void AbstractIRSpectra::changeBroadeningModel(int type)
+  {
+    m_broadeningModel = static_cast<BroadeningModel>(type);
+    updateBroadeningControls();
     emit plotDataChanged();
   }
 
@@ -208,6 +273,273 @@ namespace Avogadro {
   {
     m_labelYThreshold = t;
     emit plotDataChanged();
+  }
+
+  void AbstractIRSpectra::updateTemperature(double t)
+  {
+    m_temperature = t;
+    emit plotDataChanged();
+  }
+
+  void AbstractIRSpectra::updateReferenceTemperature(double t)
+  {
+    m_referenceTemperature = t;
+    emit plotDataChanged();
+  }
+
+  void AbstractIRSpectra::updateModelExponent(double n)
+  {
+    m_modelExponent = n;
+    emit plotDataChanged();
+  }
+
+  void AbstractIRSpectra::updateBaselineWidth(double w)
+  {
+    m_baselineWidth = w;
+    emit plotDataChanged();
+  }
+
+  void AbstractIRSpectra::updateAnharmonicAmplitude(double a)
+  {
+    m_anharmonicAmplitude = a;
+    emit plotDataChanged();
+  }
+
+  void AbstractIRSpectra::updateVoigtMix(double eta)
+  {
+    m_voigtMix = eta;
+    emit plotDataChanged();
+  }
+
+  void AbstractIRSpectra::updateBroadeningControls()
+  {
+    bool needsTemperature = (m_broadeningModel != CONSTANT_WIDTH);
+    bool needsReference = (m_broadeningModel == DOPPLER_LIKE ||
+                           m_broadeningModel == COLLISIONAL_HOMOGENEOUS);
+    bool needsExponent = (m_broadeningModel == COLLISIONAL_HOMOGENEOUS);
+    bool needsAnharmonic = (m_broadeningModel == ANHARMONIC_PHONON);
+    bool isVoigt = (m_lineShape == VOIGT);
+
+    ui.spin_temperature->setEnabled(needsTemperature);
+    ui.label_temperature->setEnabled(needsTemperature);
+    ui.spin_referenceTemperature->setEnabled(needsReference);
+    ui.label_referenceTemperature->setEnabled(needsReference);
+    ui.spin_modelExponent->setEnabled(needsExponent);
+    ui.label_modelExponent->setEnabled(needsExponent);
+    ui.spin_zeroWidth->setEnabled(needsAnharmonic);
+    ui.label_zeroWidth->setEnabled(needsAnharmonic);
+    ui.spin_anharmonicAmplitude->setEnabled(needsAnharmonic);
+    ui.label_anharmonicAmplitude->setEnabled(needsAnharmonic);
+    ui.spin_voigtMix->setEnabled(isVoigt);
+    ui.label_voigtMix->setEnabled(isVoigt);
+  }
+
+  QStringList AbstractIRSpectra::dataTableHeaders() const
+  {
+    return QStringList() << xAxisDataTableLabel() << m_yaxis;
+  }
+
+  double AbstractIRSpectra::displayXValue(double x) const
+  {
+    return displayedXFromWavenumber(x);
+  }
+
+  QString AbstractIRSpectra::xAxisLabel() const
+  {
+    switch (m_xAxisUnit) {
+      case WAVELENGTH_UM:
+        return tr("Wavelength (µm)");
+      case WAVELENGTH_NM:
+        return tr("Wavelength (nm)");
+      case ENERGY_MEV:
+        return tr("Energy (meV)");
+      case ENERGY_KJMOL:
+        return tr("Energy (kJ/mol)");
+      case WAVENUMBER_CM1:
+      default:
+        return tr("Wavenumber (cm<sup>-1</sup>)");
+    }
+  }
+
+  QString AbstractIRSpectra::xAxisDataTableLabel() const
+  {
+    switch (m_xAxisUnit) {
+      case WAVELENGTH_UM:
+        return tr("Wavelength (µm)");
+      case WAVELENGTH_NM:
+        return tr("Wavelength (nm)");
+      case ENERGY_MEV:
+        return tr("Energy (meV)");
+      case ENERGY_KJMOL:
+        return tr("Energy (kJ/mol)");
+      case WAVENUMBER_CM1:
+      default:
+        return tr("Wavenumber (cm^-1)");
+    }
+  }
+
+  void AbstractIRSpectra::setXAxisUnit(XAxisUnit unit)
+  {
+    if (unit < WAVENUMBER_CM1 || unit > ENERGY_KJMOL) {
+      unit = WAVENUMBER_CM1;
+    }
+    if (ui.combo_xaxis->currentIndex() == static_cast<int>(unit)) {
+      updateXAxis(static_cast<int>(unit));
+      return;
+    }
+    ui.combo_xaxis->setCurrentIndex(static_cast<int>(unit));
+  }
+
+  double AbstractIRSpectra::scaledWavenumber(double originalWavenumber) const
+  {
+    return originalWavenumber * scale(originalWavenumber);
+  }
+
+  double AbstractIRSpectra::displayedXFromWavenumber(double scaledWavenumber) const
+  {
+    switch (m_xAxisUnit) {
+      case WAVELENGTH_UM:
+        if (scaledWavenumber == 0.0) {
+          return 0.0;
+        }
+        return 1.0e4 / scaledWavenumber;
+      case WAVELENGTH_NM:
+        if (scaledWavenumber == 0.0) {
+          return 0.0;
+        }
+        return 1.0e7 / scaledWavenumber;
+      case ENERGY_MEV:
+        return 0.1239841984 * scaledWavenumber;
+      case ENERGY_KJMOL:
+        return 0.01196266 * scaledWavenumber;
+      case WAVENUMBER_CM1:
+      default:
+        return scaledWavenumber;
+    }
+  }
+
+  void AbstractIRSpectra::convertPlotObjectXToDisplayUnits(PlotObject *plotObject) const
+  {
+    for (int i = 0; i < plotObject->points().size(); ++i) {
+      PlotPoint *point = plotObject->points().at(i);
+      point->setX(displayedXFromWavenumber(point->x()));
+      if (!point->label().isEmpty()) {
+        point->setLabel(QString("%L1").arg(point->x(), 0, 'f', 1));
+      }
+    }
+  }
+
+  void AbstractIRSpectra::updatePlotLabels()
+  {
+    m_dialog->getUi()->plot->axis(PlotWidget::BottomAxis)->setLabel(xAxisLabel());
+    m_dialog->getUi()->plot->axis(PlotWidget::LeftAxis)->setLabel(m_yaxis);
+  }
+
+  void AbstractIRSpectra::xAxisDefaultLimits(double &xMin, double &xMax) const
+  {
+    const double highWavenumber = scaledWavenumber(3500.0);
+    const double lowWavenumber = scaledWavenumber(400.0);
+
+    if (m_xAxisUnit == WAVENUMBER_CM1) {
+      xMin = highWavenumber;
+      xMax = lowWavenumber;
+      return;
+    }
+
+    double lowDisplay = displayedXFromWavenumber(lowWavenumber);
+    double highDisplay = displayedXFromWavenumber(highWavenumber);
+    if (lowDisplay < highDisplay) {
+      xMin = lowDisplay;
+      xMax = highDisplay;
+    } else {
+      xMin = highDisplay;
+      xMax = lowDisplay;
+    }
+  }
+
+  double AbstractIRSpectra::modeledFwhm(double wavenumber) const
+  {
+    const double t = std::max(1.0, m_temperature);
+    const double tRef = std::max(1.0, m_referenceTemperature);
+    switch (m_broadeningModel) {
+      case DOPPLER_LIKE:
+        return m_fwhm * sqrt(t / tRef);
+      case COLLISIONAL_HOMOGENEOUS:
+        return m_fwhm * pow(tRef / t, m_modelExponent);
+      case ANHARMONIC_PHONON: {
+        if (wavenumber <= 0.0) {
+          return m_baselineWidth + m_anharmonicAmplitude;
+        }
+        const double c2 = 1.438776877; // K*cm
+        const double arg = c2 * (wavenumber * 0.5) / t;
+        double nBE = 0.0;
+        if (arg < 700.0) {
+          nBE = 1.0 / (exp(arg) - 1.0);
+        }
+        return m_baselineWidth + m_anharmonicAmplitude * (1.0 + 2.0 * nBE);
+      }
+      case CONSTANT_WIDTH:
+      default:
+        return m_fwhm;
+    }
+  }
+
+  double AbstractIRSpectra::effectiveMaxFwhm() const
+  {
+    double maxFwhm = 0.0;
+    for (int i = 0; i < m_xList.size(); ++i) {
+      maxFwhm = std::max(maxFwhm, modeledFwhm(m_xList.at(i)));
+    }
+    return maxFwhm;
+  }
+
+  bool AbstractIRSpectra::hasEffectiveBroadening() const
+  {
+    const double linewidthTolerance = 1.0e-3;
+    return effectiveMaxFwhm() > linewidthTolerance;
+  }
+
+  void AbstractIRSpectra::addBroadenedPeaks(PlotObject *plotObject)
+  {
+    if (m_xList.isEmpty()) {
+      return;
+    }
+
+    double maxFwhm = effectiveMaxFwhm();
+    if (maxFwhm <= 1.0e-3) {
+      return;
+    }
+
+    QList<double> xPoints = getXPoints(maxFwhm, m_nPoints);
+    for (int i = 0; i < xPoints.size(); ++i) {
+      double x = xPoints.at(i);
+      double y = 0.0;
+      for (int j = 0; j < m_yList.size(); ++j) {
+        const double center = m_xList.at(j);
+        const double intensity = m_yList.at(j);
+        const double fwhm = std::max(0.01, modeledFwhm(center));
+        const double gaussianSigma = fwhm / (2.0 * sqrt(2.0 * log(2.0)));
+        // Use area-normalized kernels for all shapes so width changes are
+        // consistent across Gaussian/Lorentzian/Pseudo-Voigt models.
+        static const double kPi = 3.14159265358979323846;
+        const double gaussian = (1.0 / (gaussianSigma * sqrt(2.0 * kPi))) *
+          exp(-(pow(x - center, 2.0)) / (2.0 * gaussianSigma * gaussianSigma));
+        const double hwhm = fwhm * 0.5;
+        const double lorentz =
+          hwhm / (kPi * ((x - center) * (x - center) + hwhm * hwhm));
+
+        if (m_lineShape == LORENTZIAN) {
+          y += intensity * lorentz;
+        } else if (m_lineShape == VOIGT) {
+          // Pseudo-Voigt approximation: linear mix of normalized Gaussian and
+          // Lorentzian kernels (not a full Voigt convolution).
+          y += intensity * (m_voigtMix * lorentz + (1.0 - m_voigtMix) * gaussian);
+        } else {
+          y += intensity * gaussian;
+        }
+      }
+      plotObject->addPoint(x, y);
+    }
   }
 
   double AbstractIRSpectra::scale(double w)

--- a/libavogadro/src/extensions/spectra/abstract_ir.h
+++ b/libavogadro/src/extensions/spectra/abstract_ir.h
@@ -85,7 +85,7 @@ namespace Avogadro {
     void updateBroadeningControls();
 
   protected:
-    double scale(double w);
+    double scale(double w) const;
     double scaledWavenumber(double originalWavenumber) const;
     double displayedXFromWavenumber(double scaledWavenumber) const;
     void convertPlotObjectXToDisplayUnits(PlotObject *plotObject) const;

--- a/libavogadro/src/extensions/spectra/abstract_ir.h
+++ b/libavogadro/src/extensions/spectra/abstract_ir.h
@@ -28,6 +28,19 @@
 namespace Avogadro {
     
   enum ScalingType { LINEAR, RELATIVE };
+  enum BroadeningModel {
+    CONSTANT_WIDTH = 0,
+    DOPPLER_LIKE,
+    COLLISIONAL_HOMOGENEOUS,
+    ANHARMONIC_PHONON
+  };
+  enum XAxisUnit {
+    WAVENUMBER_CM1 = 0,
+    WAVELENGTH_UM,
+    WAVELENGTH_NM,
+    ENERGY_MEV,
+    ENERGY_KJMOL
+  };
 
 
   // Abstract data type - no instance of it can be created
@@ -39,6 +52,12 @@ namespace Avogadro {
     AbstractIRSpectra( SpectraDialog *parent = 0 );
     virtual void setupPlot(PlotWidget * plot) = 0;
     void getCalculatedPlotObject(PlotObject *plotObject);
+    QStringList dataTableHeaders() const override;
+    double displayXValue(double x) const override;
+    virtual QString xAxisLabel() const;
+    virtual QString xAxisDataTableLabel() const;
+    void setXAxisUnit(XAxisUnit unit);
+    XAxisUnit xAxisUnit() const { return m_xAxisUnit; }
     
   protected slots:
     void toggleLabels(bool);
@@ -53,11 +72,29 @@ namespace Avogadro {
     void fwhmSliderReleased();    
     void changeScalingType(int);
     void changeLineShape(int);
+    void changeBroadeningModel(int);
     void updateYAxis(QString);
+    void updateXAxis(int);
     void rescaleFrequencies();
+    void updateTemperature(double);
+    void updateReferenceTemperature(double);
+    void updateModelExponent(double);
+    void updateBaselineWidth(double);
+    void updateAnharmonicAmplitude(double);
+    void updateVoigtMix(double);
+    void updateBroadeningControls();
 
   protected:
     double scale(double w);
+    double scaledWavenumber(double originalWavenumber) const;
+    double displayedXFromWavenumber(double scaledWavenumber) const;
+    void convertPlotObjectXToDisplayUnits(PlotObject *plotObject) const;
+    void updatePlotLabels();
+    virtual void xAxisDefaultLimits(double &xMin, double &xMax) const;
+    double modeledFwhm(double wavenumber) const;
+    double effectiveMaxFwhm() const;
+    bool hasEffectiveBroadening() const;
+    void addBroadenedPeaks(PlotObject *plotObject);
     
     Ui::Tab_IR_Raman ui;
     double m_scale;
@@ -66,8 +103,16 @@ namespace Avogadro {
     QString m_yaxis;
     QList<double> m_xList_orig;
     ScalingType m_scalingType;
+    BroadeningModel m_broadeningModel;
+    XAxisUnit m_xAxisUnit;
     LineShape m_lineShape;         // gaussian or lorentzian peaks
     int m_nPoints;                 // number of points of gaussian/lorentzian pulse
+    double m_temperature;
+    double m_referenceTemperature;
+    double m_modelExponent;
+    double m_baselineWidth;
+    double m_anharmonicAmplitude;
+    double m_voigtMix;
   };
 }
 

--- a/libavogadro/src/extensions/spectra/abstract_ir.h
+++ b/libavogadro/src/extensions/spectra/abstract_ir.h
@@ -87,7 +87,7 @@ namespace Avogadro {
   protected:
     double scale(double w) const;
     double scaledWavenumber(double originalWavenumber) const;
-    double displayedXFromWavenumber(double scaledWavenumber) const;
+    virtual double displayedXFromWavenumber(double scaledWavenumber) const;
     void convertPlotObjectXToDisplayUnits(PlotObject *plotObject) const;
     void updatePlotLabels();
     virtual void xAxisDefaultLimits(double &xMin, double &xMax) const;

--- a/libavogadro/src/extensions/spectra/abstract_ir.h
+++ b/libavogadro/src/extensions/spectra/abstract_ir.h
@@ -91,6 +91,8 @@ namespace Avogadro {
     void convertPlotObjectXToDisplayUnits(PlotObject *plotObject) const;
     void updatePlotLabels();
     virtual void xAxisDefaultLimits(double &xMin, double &xMax) const;
+    virtual void nativeXBounds(double &xMin, double &xMax) const;
+    virtual bool isNativeXValidForCurrentAxis(double x) const;
     double modeledFwhm(double wavenumber) const;
     double effectiveMaxFwhm() const;
     bool hasEffectiveBroadening() const;

--- a/libavogadro/src/extensions/spectra/ir.cpp
+++ b/libavogadro/src/extensions/spectra/ir.cpp
@@ -51,7 +51,15 @@ namespace Avogadro {
     settings.setValue("spectra/IR/gaussianWidth", m_fwhm);
     settings.setValue("spectra/IR/labelPeaks", ui.cb_labelPeaks->isChecked());
     settings.setValue("spectra/IR/yAxisUnits", ui.combo_yaxis->currentText());
+    settings.setValue("spectra/IR/xAxisUnits", static_cast<int>(xAxisUnit()));
     settings.setValue("spectra/IR/lineShape", ui.combo_lineShape->currentIndex());
+    settings.setValue("spectra/IR/broadeningModel", ui.combo_broadeningModel->currentIndex());
+    settings.setValue("spectra/IR/temperature", ui.spin_temperature->value());
+    settings.setValue("spectra/IR/referenceTemperature", ui.spin_referenceTemperature->value());
+    settings.setValue("spectra/IR/modelExponent", ui.spin_modelExponent->value());
+    settings.setValue("spectra/IR/baselineWidth", ui.spin_zeroWidth->value());
+    settings.setValue("spectra/IR/anharmonicAmplitude", ui.spin_anharmonicAmplitude->value());
+    settings.setValue("spectra/IR/voigtMix", ui.spin_voigtMix->value());
     settings.setValue("spectra/IR/nPoints", ui.spin_nPoints->value());
   }
 
@@ -68,9 +76,18 @@ namespace Avogadro {
     updateYAxis(yunit);
     if (yunit == "Absorbance (%)")
       ui.combo_yaxis->setCurrentIndex(1);
+    setXAxisUnit(static_cast<XAxisUnit>(
+      settings.value("spectra/IR/xAxisUnits", static_cast<int>(WAVENUMBER_CM1)).toInt()));
 
     ui.combo_lineShape->setCurrentIndex(settings.value("spectra/IR/lineShape", GAUSSIAN).toInt());
     m_lineShape = LineShape(ui.combo_lineShape->currentIndex());
+    ui.combo_broadeningModel->setCurrentIndex(settings.value("spectra/IR/broadeningModel", CONSTANT_WIDTH).toInt());
+    ui.spin_temperature->setValue(settings.value("spectra/IR/temperature", 298.15).toDouble());
+    ui.spin_referenceTemperature->setValue(settings.value("spectra/IR/referenceTemperature", 298.15).toDouble());
+    ui.spin_modelExponent->setValue(settings.value("spectra/IR/modelExponent", 1.0).toDouble());
+    ui.spin_zeroWidth->setValue(settings.value("spectra/IR/baselineWidth", m_fwhm).toDouble());
+    ui.spin_anharmonicAmplitude->setValue(settings.value("spectra/IR/anharmonicAmplitude", 0.0).toDouble());
+    ui.spin_voigtMix->setValue(settings.value("spectra/IR/voigtMix", 0.5).toDouble());
     ui.spin_nPoints->setValue(settings.value("spectra/IR/nPoints",10).toInt());
     emit plotDataChanged();
   }
@@ -146,8 +163,10 @@ namespace Avogadro {
   }
 
   void IRSpectra::setupPlot(PlotWidget * plot) {
-    plot->setDefaultLimits( 3500.0, 400.0, 0.0, 100.0 );
-    plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Wavenumber (cm<sup>-1</sup>)"));
+    double xMin, xMax;
+    xAxisDefaultLimits(xMin, xMax);
+    plot->setDefaultLimits(xMin, xMax, 0.0, 100.0);
+    plot->axis(PlotWidget::BottomAxis)->setLabel(xAxisLabel());
     plot->axis(PlotWidget::LeftAxis)->setLabel(m_yaxis);
   }
 
@@ -161,7 +180,7 @@ namespace Avogadro {
       }
     }
     // Add labels for gaussians?    
-    if ((m_fwhm != 0.0) && (ui.cb_labelPeaks->isChecked())) {
+    if (hasEffectiveBroadening() && ui.cb_labelPeaks->isChecked()) {
       if (ui.combo_yaxis->currentIndex() == 1) {
         assignGaussianLabels(plotObject, true, m_labelYThreshold);
         m_dialog->labelsUp(true);
@@ -199,6 +218,6 @@ namespace Avogadro {
 
   QString IRSpectra::getDataStream(PlotObject *plotObject)
   {
-      return SpectraType::getDataStream (plotObject, "Frequencies", "Intensities");
+      return SpectraType::getDataStream(plotObject, xAxisDataTableLabel(), m_yaxis);
   }
 }

--- a/libavogadro/src/extensions/spectra/nearir.cpp
+++ b/libavogadro/src/extensions/spectra/nearir.cpp
@@ -37,9 +37,18 @@ void NearIRSpectra::readSettings() {
     updateYAxis(yunit);
     if (yunit == "Transmittance (%)")
         ui.combo_yaxis->setCurrentIndex(0);
+    setXAxisUnit(static_cast<XAxisUnit>(
+      settings.value("spectra/NearIR/xAxisUnits", static_cast<int>(WAVENUMBER_CM1)).toInt()));
 
     ui.combo_lineShape->setCurrentIndex(settings.value("spectra/NearIR/lineShape", GAUSSIAN).toInt());
     m_lineShape = LineShape(ui.combo_lineShape->currentIndex());
+    ui.combo_broadeningModel->setCurrentIndex(settings.value("spectra/NearIR/broadeningModel", CONSTANT_WIDTH).toInt());
+    ui.spin_temperature->setValue(settings.value("spectra/NearIR/temperature", 298.15).toDouble());
+    ui.spin_referenceTemperature->setValue(settings.value("spectra/NearIR/referenceTemperature", 298.15).toDouble());
+    ui.spin_modelExponent->setValue(settings.value("spectra/NearIR/modelExponent", 1.0).toDouble());
+    ui.spin_zeroWidth->setValue(settings.value("spectra/NearIR/baselineWidth", m_fwhm).toDouble());
+    ui.spin_anharmonicAmplitude->setValue(settings.value("spectra/NearIR/anharmonicAmplitude", 0.0).toDouble());
+    ui.spin_voigtMix->setValue(settings.value("spectra/NearIR/voigtMix", 0.5).toDouble());
     ui.spin_nPoints->setValue(settings.value("spectra/NearIR/nPoints",10).toInt());
     emit plotDataChanged();
 }
@@ -51,7 +60,15 @@ void NearIRSpectra::writeSettings()
     settings.setValue("spectra/NearIR/gaussianWidth", m_fwhm);
     settings.setValue("spectra/NearIR/labelPeaks", ui.cb_labelPeaks->isChecked());
     settings.setValue("spectra/NearIR/yAxisUnits", ui.combo_yaxis->currentText());
+    settings.setValue("spectra/NearIR/xAxisUnits", static_cast<int>(xAxisUnit()));
     settings.setValue("spectra/NearIR/lineShape", ui.combo_lineShape->currentIndex());
+    settings.setValue("spectra/NearIR/broadeningModel", ui.combo_broadeningModel->currentIndex());
+    settings.setValue("spectra/NearIR/temperature", ui.spin_temperature->value());
+    settings.setValue("spectra/NearIR/referenceTemperature", ui.spin_referenceTemperature->value());
+    settings.setValue("spectra/NearIR/modelExponent", ui.spin_modelExponent->value());
+    settings.setValue("spectra/NearIR/baselineWidth", ui.spin_zeroWidth->value());
+    settings.setValue("spectra/NearIR/anharmonicAmplitude", ui.spin_anharmonicAmplitude->value());
+    settings.setValue("spectra/NearIR/voigtMix", ui.spin_voigtMix->value());
     settings.setValue("spectra/NearIR/nPoints", ui.spin_nPoints->value());
 }
 
@@ -109,8 +126,10 @@ bool NearIRSpectra::checkForData(Molecule * mol) {
     return true;
 }
 void NearIRSpectra::setupPlot(PlotWidget * plot) {
-  plot->setDefaultLimits( 3500.0, 400.0, 0.0, 100.0 );
-  plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Wavenumber (cm<sup>-1</sup>)"));
+  double xMin, xMax;
+  xAxisDefaultLimits(xMin, xMax);
+  plot->setDefaultLimits(xMin, xMax, 0.0, 100.0);
+  plot->axis(PlotWidget::BottomAxis)->setLabel(xAxisLabel());
   plot->axis(PlotWidget::LeftAxis)->setLabel(m_yaxis);
 }
 
@@ -124,7 +143,7 @@ void NearIRSpectra::getCalculatedPlotObject(PlotObject *plotObject) {
     }
   }
   // Add labels for gaussians?
-  if ((m_fwhm != 0.0) && (ui.cb_labelPeaks->isChecked())) {
+  if (hasEffectiveBroadening() && ui.cb_labelPeaks->isChecked()) {
     if (ui.combo_yaxis->currentIndex() == 1) {
       assignGaussianLabels(plotObject, true, m_labelYThreshold);
       m_dialog->labelsUp(true);
@@ -163,6 +182,6 @@ QString NearIRSpectra::getTSV() {
 
 QString NearIRSpectra::getDataStream(PlotObject *plotObject)
 {
-    return SpectraType::getDataStream (plotObject, "Frequencies", "Intensities");
+    return SpectraType::getDataStream(plotObject, xAxisDataTableLabel(), m_yaxis);
 }
 } // namespace Avogadro

--- a/libavogadro/src/extensions/spectra/raman.cpp
+++ b/libavogadro/src/extensions/spectra/raman.cpp
@@ -44,6 +44,11 @@ namespace Avogadro {
             this, SLOT(updateW(double)));
     ui.combo_yaxis->addItem(tr("Activity"));// (A<sup>4</sup>/amu)"));
     ui.combo_yaxis->addItem(tr("Intensity"));
+    ui.combo_xaxis->setItemText(WAVENUMBER_CM1, tr("Raman Shift (cm^-1)"));
+    ui.combo_xaxis->setItemText(WAVELENGTH_UM, tr("Equivalent Wavelength (µm)"));
+    ui.combo_xaxis->setItemText(WAVELENGTH_NM, tr("Equivalent Wavelength (nm)"));
+    ui.combo_xaxis->setItemText(ENERGY_MEV, tr("Shift Energy (meV)"));
+    ui.combo_xaxis->setItemText(ENERGY_KJMOL, tr("Shift Energy (kJ/mol)"));
     readSettings();
   }
 
@@ -61,7 +66,15 @@ namespace Avogadro {
     settings.setValue("spectra/Raman/laserWavenumber", m_W);
     settings.setValue("spectra/Raman/labelPeaks", ui.cb_labelPeaks->isChecked());
     settings.setValue("spectra/Raman/yAxisUnits", ui.combo_yaxis->currentText());
+    settings.setValue("spectra/Raman/xAxisUnits", static_cast<int>(xAxisUnit()));
     settings.setValue("spectra/Raman/lineShape", ui.combo_lineShape->currentIndex());
+    settings.setValue("spectra/Raman/broadeningModel", ui.combo_broadeningModel->currentIndex());
+    settings.setValue("spectra/Raman/temperature", ui.spin_temperature->value());
+    settings.setValue("spectra/Raman/referenceTemperature", ui.spin_referenceTemperature->value());
+    settings.setValue("spectra/Raman/modelExponent", ui.spin_modelExponent->value());
+    settings.setValue("spectra/Raman/baselineWidth", ui.spin_zeroWidth->value());
+    settings.setValue("spectra/Raman/anharmonicAmplitude", ui.spin_anharmonicAmplitude->value());
+    settings.setValue("spectra/Raman/voigtMix", ui.spin_voigtMix->value());
   }
 
   void RamanSpectra::readSettings() {
@@ -81,9 +94,18 @@ namespace Avogadro {
     updateYAxis(yunit);
     if (yunit == "Intensity")
       ui.combo_yaxis->setCurrentIndex(1);
+    setXAxisUnit(static_cast<XAxisUnit>(
+      settings.value("spectra/Raman/xAxisUnits", static_cast<int>(WAVENUMBER_CM1)).toInt()));
 
     ui.combo_lineShape->setCurrentIndex(settings.value("spectra/Raman/lineShape", GAUSSIAN).toInt());
     m_lineShape = LineShape(ui.combo_lineShape->currentIndex());
+    ui.combo_broadeningModel->setCurrentIndex(settings.value("spectra/Raman/broadeningModel", CONSTANT_WIDTH).toInt());
+    ui.spin_temperature->setValue(settings.value("spectra/Raman/temperature", 298.15).toDouble());
+    ui.spin_referenceTemperature->setValue(settings.value("spectra/Raman/referenceTemperature", 298.15).toDouble());
+    ui.spin_modelExponent->setValue(settings.value("spectra/Raman/modelExponent", 1.0).toDouble());
+    ui.spin_zeroWidth->setValue(settings.value("spectra/Raman/baselineWidth", m_fwhm).toDouble());
+    ui.spin_anharmonicAmplitude->setValue(settings.value("spectra/Raman/anharmonicAmplitude", 0.0).toDouble());
+    ui.spin_voigtMix->setValue(settings.value("spectra/Raman/voigtMix", 0.5).toDouble());
     emit plotDataChanged();
   }
 
@@ -139,8 +161,10 @@ namespace Avogadro {
   }
 
   void RamanSpectra::setupPlot(PlotWidget * plot) {
-    plot->setDefaultLimits( 3500.0, 0.0, 0.0, 1.0 );
-    plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Wavenumber (cm<sup>-1</sup>)"));
+    double xMin, xMax;
+    xAxisDefaultLimits(xMin, xMax);
+    plot->setDefaultLimits(xMin, xMax, 0.0, 1.0);
+    plot->axis(PlotWidget::BottomAxis)->setLabel(xAxisLabel());
     plot->axis(PlotWidget::LeftAxis)->setLabel(m_yaxis);
   }
 
@@ -158,7 +182,7 @@ namespace Avogadro {
     AbstractIRSpectra::getCalculatedPlotObject(plotObject);
 
     // Add labels for gaussians?
-    if ((m_fwhm != 0.0) && (ui.cb_labelPeaks->isChecked())) {
+    if (hasEffectiveBroadening() && ui.cb_labelPeaks->isChecked()) {
       assignGaussianLabels(plotObject, true, m_labelYThreshold);
       m_dialog->labelsUp(true);
     }
@@ -192,7 +216,80 @@ namespace Avogadro {
 
   QString RamanSpectra::getDataStream(PlotObject *plotObject)
   {
-      return SpectraType::getDataStream(plotObject, "Frequencies" , "Activities");
+      return SpectraType::getDataStream(plotObject, xAxisDataTableLabel(), m_yaxis);
+  }
+
+  QString RamanSpectra::xAxisLabel() const
+  {
+    switch (xAxisUnit()) {
+      case WAVELENGTH_UM:
+        return tr("Equivalent Wavelength (µm)");
+      case WAVELENGTH_NM:
+        return tr("Equivalent Wavelength (nm)");
+      case ENERGY_MEV:
+        return tr("Shift Energy (meV)");
+      case ENERGY_KJMOL:
+        return tr("Shift Energy (kJ/mol)");
+      case WAVENUMBER_CM1:
+      default:
+        return tr("Raman Shift (cm<sup>-1</sup>)");
+    }
+  }
+
+  QString RamanSpectra::xAxisDataTableLabel() const
+  {
+    switch (xAxisUnit()) {
+      case WAVELENGTH_UM:
+        return tr("Equivalent Wavelength (µm)");
+      case WAVELENGTH_NM:
+        return tr("Equivalent Wavelength (nm)");
+      case ENERGY_MEV:
+        return tr("Shift Energy (meV)");
+      case ENERGY_KJMOL:
+        return tr("Shift Energy (kJ/mol)");
+      case WAVENUMBER_CM1:
+      default:
+        return tr("Raman Shift (cm^-1)");
+    }
+  }
+
+  void RamanSpectra::xAxisDefaultLimits(double &xMin, double &xMax) const
+  {
+    const double highShift = scaledWavenumber(3500.0);
+    const double lowShift = scaledWavenumber(0.0);
+
+    if (xAxisUnit() == WAVENUMBER_CM1) {
+      xMin = highShift;
+      xMax = lowShift;
+      return;
+    }
+
+    double lowReference = lowShift;
+    if (xAxisUnit() == WAVELENGTH_UM || xAxisUnit() == WAVELENGTH_NM) {
+      bool foundPositive = false;
+      for (int i = 0; i < m_xList.size(); ++i) {
+        double shift = m_xList.at(i);
+        if (shift > 0.0) {
+          if (!foundPositive || shift < lowReference) {
+            lowReference = shift;
+            foundPositive = true;
+          }
+        }
+      }
+      if (!foundPositive) {
+        lowReference = scaledWavenumber(1.0);
+      }
+    }
+
+    double lowDisplay = displayedXFromWavenumber(lowReference);
+    double highDisplay = displayedXFromWavenumber(highShift);
+    if (lowDisplay < highDisplay) {
+      xMin = lowDisplay;
+      xMax = highDisplay;
+    } else {
+      xMin = highDisplay;
+      xMax = lowDisplay;
+    }
   }
 
   void RamanSpectra::updateT(double T)

--- a/libavogadro/src/extensions/spectra/raman.cpp
+++ b/libavogadro/src/extensions/spectra/raman.cpp
@@ -268,8 +268,13 @@ namespace Avogadro {
         }
         return 1.0e7 / scatteredWavenumber;
       }
+      case ENERGY_MEV:
+        return 0.1239841984 * scaledWavenumber;
+      case ENERGY_KJMOL:
+        return 0.01196266 * scaledWavenumber;
+      case WAVENUMBER_CM1:
       default:
-        return AbstractIRSpectra::displayedXFromWavenumber(scaledWavenumber);
+        return scaledWavenumber;
     }
   }
 

--- a/libavogadro/src/extensions/spectra/raman.cpp
+++ b/libavogadro/src/extensions/spectra/raman.cpp
@@ -45,8 +45,8 @@ namespace Avogadro {
     ui.combo_yaxis->addItem(tr("Activity"));// (A<sup>4</sup>/amu)"));
     ui.combo_yaxis->addItem(tr("Intensity"));
     ui.combo_xaxis->setItemText(WAVENUMBER_CM1, tr("Raman Shift (cm^-1)"));
-    ui.combo_xaxis->setItemText(WAVELENGTH_UM, tr("Equivalent Wavelength (µm)"));
-    ui.combo_xaxis->setItemText(WAVELENGTH_NM, tr("Equivalent Wavelength (nm)"));
+    ui.combo_xaxis->setItemText(WAVELENGTH_UM, tr("Scattered Wavelength (µm)"));
+    ui.combo_xaxis->setItemText(WAVELENGTH_NM, tr("Scattered Wavelength (nm)"));
     ui.combo_xaxis->setItemText(ENERGY_MEV, tr("Shift Energy (meV)"));
     ui.combo_xaxis->setItemText(ENERGY_KJMOL, tr("Shift Energy (kJ/mol)"));
     readSettings();
@@ -223,9 +223,9 @@ namespace Avogadro {
   {
     switch (xAxisUnit()) {
       case WAVELENGTH_UM:
-        return tr("Equivalent Wavelength (µm)");
+        return tr("Scattered Wavelength (µm)");
       case WAVELENGTH_NM:
-        return tr("Equivalent Wavelength (nm)");
+        return tr("Scattered Wavelength (nm)");
       case ENERGY_MEV:
         return tr("Shift Energy (meV)");
       case ENERGY_KJMOL:
@@ -240,9 +240,9 @@ namespace Avogadro {
   {
     switch (xAxisUnit()) {
       case WAVELENGTH_UM:
-        return tr("Equivalent Wavelength (µm)");
+        return tr("Scattered Wavelength (µm)");
       case WAVELENGTH_NM:
-        return tr("Equivalent Wavelength (nm)");
+        return tr("Scattered Wavelength (nm)");
       case ENERGY_MEV:
         return tr("Shift Energy (meV)");
       case ENERGY_KJMOL:
@@ -250,6 +250,26 @@ namespace Avogadro {
       case WAVENUMBER_CM1:
       default:
         return tr("Raman Shift (cm^-1)");
+    }
+  }
+
+  double RamanSpectra::displayedXFromWavenumber(double scaledWavenumber) const
+  {
+    switch (xAxisUnit()) {
+      case WAVELENGTH_UM:
+      case WAVELENGTH_NM: {
+        // Raman wavelengths are scattered-light wavelengths: 1/lambda_s = W - shift.
+        const double scatteredWavenumber = m_W - scaledWavenumber;
+        if (scatteredWavenumber <= 0.0) {
+          return 0.0;
+        }
+        if (xAxisUnit() == WAVELENGTH_UM) {
+          return 1.0e4 / scatteredWavenumber;
+        }
+        return 1.0e7 / scatteredWavenumber;
+      }
+      default:
+        return AbstractIRSpectra::displayedXFromWavenumber(scaledWavenumber);
     }
   }
 

--- a/libavogadro/src/extensions/spectra/raman.cpp
+++ b/libavogadro/src/extensions/spectra/raman.cpp
@@ -25,6 +25,8 @@
 #include <QtCore/QDebug>
 
 #include <openbabel/mol.h>
+#include <algorithm>
+#include <cmath>
 
 const double k=1.3806504e-23,
              h=6.62606896e-34,
@@ -33,6 +35,10 @@ const double k=1.3806504e-23,
 using namespace std;
 
 namespace Avogadro {
+  namespace {
+    const double kMinDenominator = 1.0e-12;
+    const double kMinPositiveShift = 1.0e-8;
+  }
 
   RamanSpectra::RamanSpectra( SpectraDialog *parent ) :
     AbstractIRSpectra( parent )
@@ -172,8 +178,26 @@ namespace Avogadro {
     for(int i = 0; i< m_yList.size(); i++) {
       // Convert to intensities?
       if (ui.combo_yaxis->currentIndex() == 1) {
-        m_yList[i] = m_yList_orig.at(i)*1e-8/m_xList.at(i) * pow(((m_W - m_xList.at(i))),4)
-         * (1 + exp(-h*c*m_xList.at(i)/(k*m_T)));
+        const double shift = m_xList.at(i);
+        const double activity = m_yList_orig.at(i);
+        if (!std::isfinite(shift) || !std::isfinite(activity) ||
+            !std::isfinite(m_W) || !std::isfinite(m_T) ||
+            shift <= kMinPositiveShift || m_T <= kMinDenominator) {
+          m_yList[i] = 0.0;
+          continue;
+        }
+        const double scattered = m_W - shift;
+        if (!std::isfinite(scattered)) {
+          m_yList[i] = 0.0;
+          continue;
+        }
+        const double boltzArg = -h * c * shift / (k * m_T);
+        double boltz = 1.0;
+        if (std::isfinite(boltzArg) && boltzArg > -700.0 && boltzArg < 700.0) {
+          boltz += exp(boltzArg);
+        }
+        const double intensity = activity * 1e-8 / shift * pow(scattered, 4) * boltz;
+        m_yList[i] = std::isfinite(intensity) ? intensity : 0.0;
       } else {
         m_yList[i] = m_yList_orig.at(i);
       }
@@ -255,12 +279,16 @@ namespace Avogadro {
 
   double RamanSpectra::displayedXFromWavenumber(double scaledWavenumber) const
   {
+    if (!std::isfinite(scaledWavenumber)) {
+      return 0.0;
+    }
     switch (xAxisUnit()) {
       case WAVELENGTH_UM:
       case WAVELENGTH_NM: {
         // Raman wavelengths are scattered-light wavelengths: 1/lambda_s = W - shift.
         const double scatteredWavenumber = m_W - scaledWavenumber;
-        if (scatteredWavenumber <= 0.0) {
+        if (!std::isfinite(scatteredWavenumber) ||
+            scatteredWavenumber <= kMinDenominator) {
           return 0.0;
         }
         if (xAxisUnit() == WAVELENGTH_UM) {
@@ -276,6 +304,31 @@ namespace Avogadro {
       default:
         return scaledWavenumber;
     }
+  }
+
+  void RamanSpectra::nativeXBounds(double &xMin, double &xMax) const
+  {
+    AbstractIRSpectra::nativeXBounds(xMin, xMax);
+    if (xAxisUnit() == WAVELENGTH_UM || xAxisUnit() == WAVELENGTH_NM) {
+      xMin = std::max(xMin, kMinPositiveShift);
+      const double scatteredLimit = m_W - kMinDenominator;
+      if (std::isfinite(scatteredLimit)) {
+        xMax = std::min(xMax, scatteredLimit);
+      }
+    }
+  }
+
+  bool RamanSpectra::isNativeXValidForCurrentAxis(double x) const
+  {
+    if (!AbstractIRSpectra::isNativeXValidForCurrentAxis(x)) {
+      return false;
+    }
+    if (xAxisUnit() == WAVELENGTH_UM || xAxisUnit() == WAVELENGTH_NM) {
+      const double scatteredWavenumber = m_W - x;
+      return std::isfinite(scatteredWavenumber) &&
+             scatteredWavenumber > kMinDenominator;
+    }
+    return true;
   }
 
   void RamanSpectra::xAxisDefaultLimits(double &xMin, double &xMax) const

--- a/libavogadro/src/extensions/spectra/raman.h
+++ b/libavogadro/src/extensions/spectra/raman.h
@@ -46,6 +46,7 @@ namespace Avogadro {
   protected:
     QString xAxisLabel() const override;
     QString xAxisDataTableLabel() const override;
+    double displayedXFromWavenumber(double scaledWavenumber) const override;
     void xAxisDefaultLimits(double &xMin, double &xMax) const override;
 
   private slots:

--- a/libavogadro/src/extensions/spectra/raman.h
+++ b/libavogadro/src/extensions/spectra/raman.h
@@ -48,6 +48,8 @@ namespace Avogadro {
     QString xAxisDataTableLabel() const override;
     double displayedXFromWavenumber(double scaledWavenumber) const override;
     void xAxisDefaultLimits(double &xMin, double &xMax) const override;
+    void nativeXBounds(double &xMin, double &xMax) const override;
+    bool isNativeXValidForCurrentAxis(double x) const override;
 
   private slots:
     void updateT(double);

--- a/libavogadro/src/extensions/spectra/raman.h
+++ b/libavogadro/src/extensions/spectra/raman.h
@@ -42,6 +42,12 @@ namespace Avogadro {
     void getCalculatedPlotObject(PlotObject *plotObject);
     QString getTSV();
     QString getDataStream(PlotObject *plotObject);
+
+  protected:
+    QString xAxisLabel() const override;
+    QString xAxisDataTableLabel() const override;
+    void xAxisDefaultLimits(double &xMin, double &xMax) const override;
+
   private slots:
     void updateT(double);
     void updateW(double);

--- a/libavogadro/src/extensions/spectra/spectradialog.cpp
+++ b/libavogadro/src/extensions/spectra/spectradialog.cpp
@@ -66,7 +66,6 @@ namespace Avogadro {
   {
     ui.setupUi(this);
     setWindowFlags(Qt::Window);
-    ui.dataTable->horizontalHeader()->setVisible(true);
     ui.dataTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
 
     // Set up spectra variables

--- a/libavogadro/src/extensions/spectra/spectradialog.cpp
+++ b/libavogadro/src/extensions/spectra/spectradialog.cpp
@@ -66,6 +66,7 @@ namespace Avogadro {
   {
     ui.setupUi(this);
     setWindowFlags(Qt::Window);
+    ui.dataTable->horizontalHeader()->setVisible(true);
     ui.dataTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
 
     // Set up spectra variables

--- a/libavogadro/src/extensions/spectra/spectradialog.cpp
+++ b/libavogadro/src/extensions/spectra/spectradialog.cpp
@@ -1188,6 +1188,9 @@ namespace Avogadro {
       ui.currentCoordinates->setText("");
       return;
     }
+    if (!m_time.isValid()) {
+      m_time.start();
+    }
     // Don't update coordinates more often than once in 0.1 sec
     int t = m_time.elapsed();
     if (t - m_lastUpdate > 100) {
@@ -1199,7 +1202,7 @@ namespace Avogadro {
   void SpectraDialog::showEvent ( QShowEvent * event )
   {
     m_lastUpdate = 0;
-    m_time.restart();
+    m_time.start();
     event->accept();
   }
 }

--- a/libavogadro/src/extensions/spectra/spectradialog.h
+++ b/libavogadro/src/extensions/spectra/spectradialog.h
@@ -26,7 +26,7 @@
 #include <QtCore/QHash>
 #include <QtCore/QVariant>
 #include <QtCore/QSettings>
-#include <QtCore/QTime>
+#include <QtCore/QElapsedTimer>
 
 #include <avogadro/primitive.h>
 #include <avogadro/plotwidget.h>
@@ -124,7 +124,7 @@ namespace Avogadro {
     PlotObject *m_importedSpectra;
     PlotObject *m_nullSpectra;
 
-    QTime m_time;
+    QElapsedTimer m_time;
     int m_lastUpdate;
     bool m_labelsUp;
   };

--- a/libavogadro/src/extensions/spectra/spectradialog.ui
+++ b/libavogadro/src/extensions/spectra/spectradialog.ui
@@ -88,7 +88,7 @@ Scroll wheel: Zoom to cursor</string>
       <bool>true</bool>
      </property>
      <attribute name="horizontalHeaderVisible">
-      <bool>false</bool>
+      <bool>true</bool>
      </attribute>
      <attribute name="horizontalHeaderCascadingSectionResizes">
       <bool>false</bool>

--- a/libavogadro/src/extensions/spectra/spectratype.cpp
+++ b/libavogadro/src/extensions/spectra/spectratype.cpp
@@ -71,7 +71,7 @@ namespace Avogadro {
   {
     plotObject->clearPoints();
     for (int i = 0; i < m_xList_imp.size(); i++) {
-      plotObject->addPoint(m_xList_imp.at(i), m_yList_imp.at(i));
+      plotObject->addPoint(displayXValue(m_xList_imp.at(i)), m_yList_imp.at(i));
     }
   }
   
@@ -101,12 +101,19 @@ namespace Avogadro {
   {
     if ((!m_dialog) || (m_xList.size()==0))
       return;
+    QTableWidget *table = m_dialog->getUi()->dataTable;
+    bool sortingEnabled = table->isSortingEnabled();
+    if (sortingEnabled) {
+      table->setSortingEnabled(false);
+    }
+    table->setHorizontalHeaderLabels(dataTableHeaders());
     //m_dialog->getUi()->dataTable->clear();
-    m_dialog->getUi()->dataTable->setRowCount(m_xList.size());
+    table->setRowCount(m_xList.size());
     QString format("%1");
     int xfmtsize = 2;
     int yfmtsize = 3;
-    if (abs(m_xList.at(0) - m_xList.at(m_xList.size()-1)) < 10) xfmtsize = 4;
+    if (abs(displayXValue(m_xList.at(0)) -
+            displayXValue(m_xList.at(m_xList.size()-1))) < 10) xfmtsize = 4;
     yfmtsize = 6;
     for (int i = 0; i < m_yList.size(); i++) {
         if (m_yList.at(i) > 1.) {
@@ -115,25 +122,36 @@ namespace Avogadro {
         }
     }
     for (int i = 0; i < m_xList.size(); i++) {
-      QString xString = format.arg(m_xList.at(i), 0, 'f', xfmtsize);
+      QString xString = format.arg(displayXValue(m_xList.at(i)), 0, 'f', xfmtsize);
       QString yString;
       if (i < m_yList.size()) {
         yString = format.arg(m_yList.at(i), 0, 'f', yfmtsize);
       } else {
         yString = "-";
       }
-      if (!m_dialog->getUi()->dataTable->item(i,0)) {
+      if (!table->item(i,0)) {
         QTableWidgetItem *newX = new QTableWidgetItem(xString);
         newX->setTextAlignment(Qt::AlignRight|Qt::AlignVCenter);
         QTableWidgetItem *newY = new QTableWidgetItem(yString);
         newY->setTextAlignment(Qt::AlignRight|Qt::AlignVCenter);
-        m_dialog->getUi()->dataTable->setItem(i, 0, newX);
-        m_dialog->getUi()->dataTable->setItem(i, 1, newY);
+        table->setItem(i, 0, newX);
+        table->setItem(i, 1, newY);
       } else {
-        m_dialog->getUi()->dataTable->item(i,0)->setText(xString);
-        m_dialog->getUi()->dataTable->item(i,1)->setText(yString);
+        table->item(i,0)->setText(xString);
+        table->item(i,1)->setText(yString);
       }      
     }
+    table->setSortingEnabled(sortingEnabled);
+  }
+
+  QStringList SpectraType::dataTableHeaders() const
+  {
+    return QStringList() << tr("X") << tr("Y");
+  }
+
+  double SpectraType::displayXValue(double x) const
+  {
+    return x;
   }
 
   QList<double> SpectraType::getXPoints(double FWHM, uint dotsPerPeak)

--- a/libavogadro/src/extensions/spectra/spectratype.cpp
+++ b/libavogadro/src/extensions/spectra/spectratype.cpp
@@ -31,6 +31,8 @@
 #include <avogadro/primitive.h>
 #include <avogadro/molecule.h>
 
+#include <cmath>
+
 namespace Avogadro {
 
   SpectraType::SpectraType( SpectraDialog *parent ) : QObject(parent), m_dialog(parent)
@@ -112,8 +114,8 @@ namespace Avogadro {
     QString format("%1");
     int xfmtsize = 2;
     int yfmtsize = 3;
-    if (abs(displayXValue(m_xList.at(0)) -
-            displayXValue(m_xList.at(m_xList.size()-1))) < 10) xfmtsize = 4;
+    if (std::abs(displayXValue(m_xList.at(0)) -
+                 displayXValue(m_xList.at(m_xList.size()-1))) < 10) xfmtsize = 4;
     yfmtsize = 6;
     for (int i = 0; i < m_yList.size(); i++) {
         if (m_yList.at(i) > 1.) {

--- a/libavogadro/src/extensions/spectra/spectratype.h
+++ b/libavogadro/src/extensions/spectra/spectratype.h
@@ -22,6 +22,7 @@
 #define SPECTRATYPE_H
 
 #include <QDialog>
+#include <QStringList>
 #include <QtCore/QHash>
 #include <QtCore/QVariant>
 #include <QtCore/QSettings>
@@ -61,6 +62,8 @@ namespace Avogadro {
     virtual void setImportedData(const QList<double> & xList, const QList<double> & yList);
     virtual void getImportedPlotObject(PlotObject *plotObject);
     virtual void updateDataTable();
+    virtual QStringList dataTableHeaders() const;
+    virtual double displayXValue(double x) const;
 
     // No need to override these functions
     QList<double> getXPoints(double FWHM, uint dotsPerPeak);

--- a/libavogadro/src/extensions/spectra/tab_ir_raman.ui
+++ b/libavogadro/src/extensions/spectra/tab_ir_raman.ui
@@ -59,6 +59,45 @@
         </property>
        </spacer>
       </item>
+      <item row="0" column="4">
+       <widget class="QLabel" name="label_xaxis">
+        <property name="text">
+         <string>X Axis Units:</string>
+        </property>
+        <property name="buddy">
+         <cstring>combo_xaxis</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5" colspan="2">
+       <widget class="QComboBox" name="combo_xaxis">
+        <item>
+         <property name="text">
+          <string>Wavenumber (cm^-1)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Wavelength (µm)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Wavelength (nm)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Energy (meV)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Energy (kJ/mol)</string>
+         </property>
+        </item>
+       </widget>
+      </item>
       <item row="0" column="7">
        <spacer name="horizontalSpacer_4">
         <property name="orientation">
@@ -236,6 +275,11 @@
           <item>
            <property name="text">
             <string>Lorentzian</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Pseudo-Voigt</string>
            </property>
           </item>
          </widget>
@@ -514,6 +558,173 @@
         </property>
         <property name="maximum">
          <number>25</number>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_broadeningModel">
+        <property name="text">
+         <string>Broadening Model:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1" colspan="2">
+       <widget class="QComboBox" name="combo_broadeningModel">
+        <item>
+         <property name="text">
+          <string>Constant width</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Doppler-like (sqrt(T))</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Collisional / homogeneous</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Anharmonic phonon (Bose)</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="6" column="3">
+       <widget class="QLabel" name="label_temperature">
+        <property name="text">
+         <string>Temperature:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="4">
+       <widget class="QDoubleSpinBox" name="spin_temperature">
+        <property name="suffix">
+         <string> K</string>
+        </property>
+        <property name="minimum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>5000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>298.149999999999977</double>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="5">
+       <widget class="QLabel" name="label_referenceTemperature">
+        <property name="text">
+         <string>Reference T:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="6">
+       <widget class="QDoubleSpinBox" name="spin_referenceTemperature">
+        <property name="suffix">
+         <string> K</string>
+        </property>
+        <property name="minimum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>5000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>298.149999999999977</double>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_modelExponent">
+        <property name="text">
+         <string>Exponent n:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QDoubleSpinBox" name="spin_modelExponent">
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="maximum">
+         <double>5.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="2">
+       <widget class="QLabel" name="label_zeroWidth">
+        <property name="text">
+         <string>Baseline width:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="3">
+       <widget class="QDoubleSpinBox" name="spin_zeroWidth">
+        <property name="suffix">
+         <string> cm^-1</string>
+        </property>
+        <property name="maximum">
+         <double>1000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="4">
+       <widget class="QLabel" name="label_anharmonicAmplitude">
+        <property name="text">
+         <string>Anharmonic A:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="5">
+       <widget class="QDoubleSpinBox" name="spin_anharmonicAmplitude">
+        <property name="suffix">
+         <string> cm^-1</string>
+        </property>
+        <property name="maximum">
+         <double>1000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="6">
+       <widget class="QLabel" name="label_voigtMix">
+        <property name="text">
+         <string>Pseudo-Voigt η:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="7">
+       <widget class="QDoubleSpinBox" name="spin_voigtMix">
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="maximum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.050000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.500000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0" colspan="8">
+       <widget class="QLabel" name="label_broadeningHelp">
+        <property name="text">
+         <string>Vibrational broadening is a phenomenological visualization model for discrete transitions (not uniquely determined by a harmonic ORCA frequency job).</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/scripts/installer/create_installer.py
+++ b/scripts/installer/create_installer.py
@@ -163,15 +163,52 @@ def main():
     zlib_lib = os.environ.get("ZLIB_LIBRARY")
     zlib_dir = os.environ.get("ZLIB_LIBRARY_DIR")
     candidates = []
-    if zlib_lib:
-        candidates.append(Path(zlib_lib).with_suffix('.dll'))
     if zlib_dir:
-        candidates.append(Path(zlib_dir) / 'zlib1.dll')
-        candidates.append(Path(zlib_dir) / 'zlib.dll')
-    for dll in candidates:
+        zdir = Path(zlib_dir)
+        candidates.extend([
+            zdir.parent / "bin" / "z.dll",
+            zdir.parent / "bin" / "zlib.dll",
+            zdir.parent / "bin" / "zlib1.dll",
+        ])
+    if zlib_lib:
+        zlib_path = Path(zlib_lib)
+        candidates.extend([
+            zlib_path.parent.parent / "bin" / "z.dll",
+            zlib_path.parent.parent / "bin" / "zlib.dll",
+            zlib_path.parent.parent / "bin" / "zlib1.dll",
+            zlib_path.with_suffix(".dll"),
+        ])
+    if zlib_dir:
+        zdir = Path(zlib_dir)
+        candidates.extend([
+            zdir / "zlib1.dll",
+            zdir / "zlib.dll",
+        ])
+
+    # preserve order while deduplicating
+    seen = set()
+    zlib_candidates = []
+    for c in candidates:
+        key = str(c)
+        if key not in seen:
+            seen.add(key)
+            zlib_candidates.append(c)
+
+    zlib_runtime = None
+    for dll in zlib_candidates:
         if dll.exists():
-            copy(dll, dist / 'bin')
+            zlib_runtime = dll
             break
+
+    if zlib_runtime:
+        print(f"Using zlib runtime DLL: {zlib_runtime}")
+        copy(zlib_runtime, dist / "bin")
+    elif zlib_lib or zlib_dir:
+        attempted = "\n".join(str(p) for p in zlib_candidates) or "<none>"
+        raise FileNotFoundError(
+            "Could not locate zlib runtime DLL from provided ZLIB variables. "
+            f"Tried:\n{attempted}"
+        )
 
     glew_bin = os.environ.get("GLEW_BIN_DIR")
     if glew_bin:

--- a/scripts/installer/probe_openbabel_runtime.py
+++ b/scripts/installer/probe_openbabel_runtime.py
@@ -118,7 +118,14 @@ def main() -> int:
     env = os.environ.copy()
     env["BABEL_LIBDIR"] = str(plugin_dir)
     env["BABEL_DATADIR"] = str(data_dir)
-    env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
+    system_root = env.get("SystemRoot", r"C:\Windows")
+    restricted_path_parts = [
+        str(bin_dir),
+        str(Path(system_root) / "System32"),
+        system_root,
+        str(Path(system_root) / "System32" / "Wbem"),
+    ]
+    env["PATH"] = os.pathsep.join(restricted_path_parts)
 
     dll_dir_handles = []
     if hasattr(os, "add_dll_directory"):
@@ -184,6 +191,12 @@ def main() -> int:
     formats_xml_load_ok = formats_xml.exists()
     ctypes_all_ok = all(result[0] for result in load_results.values())
     openbabel_dll_load_ok = load_results.get(str(openbabel_dll), (False, "not attempted"))[0]
+    print(f"subprocess_probe_PATH={env['PATH']}")
+    if not openbabel_dll_load_ok:
+        _list_paths(sorted(bin_dir.glob("*.dll")), "dist/bin DLLs")
+        for name in ("z.dll", "zlib.dll", "zlib1.dll"):
+            candidate = bin_dir / name
+            print(f"{name}: exists={candidate.exists()} path={candidate}")
     obabel_launch_ok = all(
         cmd_results.get(" ".join(cmd), (1, "", ""))[0] == 0
         for cmd in commands

--- a/scripts/installer/probe_openbabel_runtime.py
+++ b/scripts/installer/probe_openbabel_runtime.py
@@ -127,10 +127,12 @@ def main() -> int:
         dll_dir_handles.append(os.add_dll_directory(str(plugin_dir)))
 
     _print_header("ctypes direct-load probes")
-    load_targets: list[Path] = [openbabel_dll]
+    # Load known OpenBabel runtime dependencies first, then openbabel-3.dll.
+    load_targets: list[Path] = []
     load_targets.extend(libxml_dlls[:1])
     load_targets.extend(maeparser_dlls[:1])
     load_targets.extend(coordgen_dlls[:1])
+    load_targets.append(openbabel_dll)
     # NOTE: .obf files are OpenBabel plugin descriptors/modules, not plain DLLs.
     # They should be validated through obabel runtime probes instead of ctypes.
 
@@ -180,6 +182,8 @@ def main() -> int:
     formats_list_out = cmd_results.get(formats_key, (1, "", ""))[1]
     cml_in_list = bool(re.search(r"(?im)^\s*cml(\s|$)", formats_list_out))
     formats_xml_load_ok = formats_xml.exists()
+    ctypes_all_ok = all(result[0] for result in load_results.values())
+    openbabel_dll_load_ok = load_results.get(str(openbabel_dll), (False, "not attempted"))[0]
     obabel_launch_ok = all(
         cmd_results.get(" ".join(cmd), (1, "", ""))[0] == 0
         for cmd in commands
@@ -187,6 +191,8 @@ def main() -> int:
 
     _print_header("Heuristic summary")
     print(f"obabel_launch_ok={obabel_launch_ok}")
+    print(f"ctypes_loads_ok={ctypes_all_ok}")
+    print(f"openbabel_dll_load_ok={openbabel_dll_load_ok}")
     print(f"cml_listed_by_obabel={cml_in_list}")
     print(f"formats_xml_obf_loadable={formats_xml_load_ok}")
     print(f"sample_cml_conversion_ok={conversion_ok}")
@@ -194,6 +200,8 @@ def main() -> int:
     likely = "another runtime issue"
     if not formats_xml.exists():
         likely = "plugin missing"
+    elif not ctypes_all_ok:
+        likely = "dll dependency load failure"
     elif not obabel_launch_ok:
         likely = "executable launch failure"
     elif not cml_in_list:
@@ -203,6 +211,9 @@ def main() -> int:
     print(f"likely_failure_class={likely}")
 
     fail = False
+    if not ctypes_all_ok:
+        print("FAIL: one or more packaged runtime DLL probes failed via ctypes.", file=sys.stderr)
+        fail = True
     if not obabel_launch_ok:
         print("FAIL: packaged obabel.exe command probes failed to execute successfully.", file=sys.stderr)
         fail = True

--- a/scripts/installer/probe_openbabel_runtime.py
+++ b/scripts/installer/probe_openbabel_runtime.py
@@ -131,9 +131,8 @@ def main() -> int:
     load_targets.extend(libxml_dlls[:1])
     load_targets.extend(maeparser_dlls[:1])
     load_targets.extend(coordgen_dlls[:1])
-    if formats_common.exists():
-        load_targets.append(formats_common)
-    load_targets.extend([formats_xml, plugin_descriptors])
+    # NOTE: .obf files are OpenBabel plugin descriptors/modules, not plain DLLs.
+    # They should be validated through obabel runtime probes instead of ctypes.
 
     load_results: dict[str, tuple[bool, str]] = {}
     for target in load_targets:
@@ -180,7 +179,7 @@ def main() -> int:
     formats_key = f"{obabel_exe} -L formats"
     formats_list_out = cmd_results.get(formats_key, (1, "", ""))[1]
     cml_in_list = bool(re.search(r"(?im)^\s*cml(\s|$)", formats_list_out))
-    formats_xml_load_ok = load_results.get(str(formats_xml), (False, "not attempted"))[0]
+    formats_xml_load_ok = formats_xml.exists()
     obabel_launch_ok = all(
         cmd_results.get(" ".join(cmd), (1, "", ""))[0] == 0
         for cmd in commands
@@ -195,8 +194,6 @@ def main() -> int:
     likely = "another runtime issue"
     if not formats_xml.exists():
         likely = "plugin missing"
-    elif not formats_xml_load_ok:
-        likely = "plugin dependency load failure"
     elif not obabel_launch_ok:
         likely = "executable launch failure"
     elif not cml_in_list:
@@ -206,9 +203,6 @@ def main() -> int:
     print(f"likely_failure_class={likely}")
 
     fail = False
-    if not formats_xml_load_ok:
-        print("FAIL: formats_xml.obf is not loadable via ctypes.", file=sys.stderr)
-        fail = True
     if not obabel_launch_ok:
         print("FAIL: packaged obabel.exe command probes failed to execute successfully.", file=sys.stderr)
         fail = True


### PR DESCRIPTION
### Motivation
- Provide flexible X-axis units (wavenumber, wavelength, and energy) for IR/Raman/Near-IR spectra and ensure labels/data export reflect the selected units.
- Improve spectral broadening support by adding multiple phenomenological broadening models and pseudo-Voigt mixing to better visualize vibrational linewidth effects.
- Make the data table and exported data reflect display units and enable the header row for clarity.

### Description
- Added new enums and state to `AbstractIRSpectra` for `BroadeningModel` and `XAxisUnit`, and new parameters for temperature, reference temperature, model exponent, baseline width, anharmonic amplitude, and Voigt mix; implemented `modeledFwhm`, `effectiveMaxFwhm`, `hasEffectiveBroadening`, and broadened-peak generation via `addBroadenedPeaks` (area-normalized kernels) in `abstract_ir.cpp/.h`.
- Implemented X-axis conversions and labels: `scaledWavenumber`, `displayedXFromWavenumber`, `convertPlotObjectXToDisplayUnits`, `xAxisLabel`, `xAxisDataTableLabel`, and `xAxisDefaultLimits`, and hooked these into plotting and data export flows so the plot, data table, and TSV/DataStream use the selected display units.
- UI changes: added `combo_xaxis`, `combo_broadeningModel`, and several spin controls to `tab_ir_raman.ui`, enabled the data table horizontal header in `spectradialog.ui`, and exposed/bound new controls in `abstract_ir` constructor.
- Updated `SpectraType` to format and populate the data table using display X values by overriding `dataTableHeaders()` and `displayXValue()`, and to disable/restore sorting while updating the table in `spectratype.cpp/.h`.
- Updated IR/NearIR/Raman implementations to persist and restore the new settings keys, use the new axis/label helpers, and to call `hasEffectiveBroadening()` when deciding to label peaks and when generating broadened traces.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc8a792a48333bf9d32dfe623e14c)