### PR TITLE
Add vdW enclosing radius to Molecule Properties with selection-aware updates

### DIFF
--- a/libavogadro/src/extensions/molecularpropdialog.ui
+++ b/libavogadro/src/extensions/molecularpropdialog.ui
@@ -30,21 +30,21 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="atomsLabel">
        <property name="text">
         <string>Number of Atoms:</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="bondsLabel">
        <property name="text">
         <string>Number of Bonds:</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="0">
+     <item row="8" column="0">
       <widget class="QLabel" name="residuesLabel">
        <property name="text">
         <string>Number of Residues:</string>
@@ -93,21 +93,41 @@
        </property>
       </widget>
      </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="vdwRadiusLabel">
+       <property name="toolTip">
+        <string>Maximum distance from the selected atoms’ geometric center to their van der Waals surfaces. No selection means whole molecule.</string>
+       </property>
+       <property name="text">
+        <string>vdW Enclosing Radius (Å):</string>
+       </property>
+      </widget>
+     </item>
      <item row="5" column="1">
-      <widget class="QLabel" name="atomsLine">
+      <widget class="QLabel" name="vdwRadiusLine">
+       <property name="toolTip">
+        <string>Maximum distance from the selected atoms’ geometric center to their van der Waals surfaces. No selection means whole molecule.</string>
+       </property>
        <property name="readOnly" stdset="0">
         <bool>true</bool>
        </property>
       </widget>
      </item>
      <item row="6" column="1">
-      <widget class="QLabel" name="bondsLine">
+      <widget class="QLabel" name="atomsLine">
        <property name="readOnly" stdset="0">
         <bool>true</bool>
        </property>
       </widget>
      </item>
      <item row="7" column="1">
+      <widget class="QLabel" name="bondsLine">
+       <property name="readOnly" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
       <widget class="QLabel" name="residuesLine">
        <property name="readOnly" stdset="0">
         <bool>true</bool>

--- a/libavogadro/src/extensions/molecularpropextension.cpp
+++ b/libavogadro/src/extensions/molecularpropextension.cpp
@@ -21,9 +21,11 @@
 
 #include "molecularpropextension.h"
 
-#include <avogadro/primitive.h>
 #include <avogadro/glwidget.h>
 #include <avogadro/molecule.h>
+#include <avogadro/primitive.h>
+
+#include "vdwradiuscalculator.h"
 
 #include <openbabel/mol.h>
 #include <openbabel/obconversion.h>
@@ -34,6 +36,7 @@
 #include <QtCore/QDebug>
 #include <QtCore/QTimer>
 
+
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkReply>
 #include <QtNetwork/QSslSocket>
@@ -43,7 +46,9 @@ using namespace OpenBabel;
 namespace Avogadro {
 
   MolecularPropertiesExtension::MolecularPropertiesExtension(QObject *parent) : Extension(parent),
-                                                                                m_molecule(0), m_dialog(0),
+                                                                                m_molecule(0),
+                                                                                m_widget(0),
+                                                                                m_dialog(0),
                                                                                 m_inchi(),
                                                                                 m_network(0),
                                                                                 m_nameRequestPending(false)
@@ -80,14 +85,16 @@ namespace Avogadro {
     if (!m_molecule)
       return 0; // nothing we can do
 
-    // Disconnect in case we're attached to a new widget
+    disconnect( m_molecule, 0, this, 0 );
     if (m_widget)
-      disconnect( m_molecule, 0, this, 0 );
+      disconnect( m_widget, 0, this, 0 );
 
-    if (widget) {
-      connect(widget, SIGNAL(moleculeChanged(Molecule *)),
+    m_widget = widget;
+    if (m_widget) {
+      connect(m_widget, SIGNAL(moleculeChanged(Molecule *)),
               this, SLOT(moleculeChanged(Molecule*)));
-      m_widget = widget;
+      connect(m_widget, SIGNAL(selectionChanged()),
+              this, SLOT(updateVdwRadius()));
     }
 
     if (!m_dialog) {
@@ -163,6 +170,9 @@ namespace Avogadro {
     m_dialog->dipoleMomentLine->setText(format.arg(m_molecule->dipoleMoment(&estimate).norm(), 0, 'f', 3));
     if (estimate)
       m_dialog->dipoleLabel->setText(tr("Estimated Dipole Moment (D):"));
+
+    updateVdwRadius();
+
     m_dialog->atomsLine->setText(format.arg(m_molecule->numAtoms()));
     m_dialog->bondsLine->setText(format.arg(m_molecule->numBonds()));
     if (m_molecule->numResidues() < 2) {
@@ -174,6 +184,20 @@ namespace Avogadro {
       m_dialog->residuesLine->show();
       m_dialog->residuesLine->setText(format.arg(m_molecule->numResidues()));
     }
+  }
+
+  void MolecularPropertiesExtension::updateVdwRadius()
+  {
+    if (!m_dialog || !m_molecule)
+      return;
+
+    QString format("%L1");
+    QList<Atom*> atoms = MolecularProperties::atomsForVdwRadius(m_molecule, m_widget);
+    if (atoms.isEmpty())
+      m_dialog->vdwRadiusLine->setText(tr("unknown"));
+    else
+      m_dialog->vdwRadiusLine->setText(
+        format.arg(MolecularProperties::vdwEnclosingRadius(atoms), 0, 'f', 3));
   }
 
   void MolecularPropertiesExtension::updatePrimitives(Primitive*)
@@ -200,6 +224,8 @@ namespace Avogadro {
   {
     // don't ask for more updates
     disconnect( m_molecule, 0, this, 0 );
+    if (m_widget)
+      disconnect( m_widget, 0, this, 0 );
   }
 
   void MolecularPropertiesExtension::clearName()

--- a/libavogadro/src/extensions/molecularpropextension.h
+++ b/libavogadro/src/extensions/molecularpropextension.h
@@ -71,6 +71,7 @@ namespace Avogadro {
     public Q_SLOTS:
       // Slots to take signals from Molecules, and GLWidget
       void update();
+      void updateVdwRadius();
       void updatePrimitives(Primitive*);
       void updateAtoms(Atom*);
       void updateBonds(Bond*);

--- a/libavogadro/src/extensions/vdwradiuscalculator.h
+++ b/libavogadro/src/extensions/vdwradiuscalculator.h
@@ -1,0 +1,119 @@
+/**********************************************************************
+  VdwRadiusCalculator - van der Waals enclosing radius helpers
+
+  This file is part of the Avogadro molecular editor project.
+  For more information, see <http://avogadro.cc/>
+
+  Avogadro is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+ ***********************************************************************/
+
+#ifndef VDWRADIUSCALCULATOR_H
+#define VDWRADIUSCALCULATOR_H
+
+#include <avogadro/atom.h>
+#include <avogadro/bond.h>
+#include <avogadro/glwidget.h>
+#include <avogadro/molecule.h>
+#include <avogadro/primitive.h>
+#include <avogadro/primitivelist.h>
+
+#include <openbabel/elements.h>
+
+#include <Eigen/Core>
+
+#include <QtCore/QList>
+#include <QtCore/QSet>
+#include <QtCore/QtGlobal>
+
+namespace Avogadro {
+namespace MolecularProperties {
+
+  static inline double atomVdwRadius(const Atom *atom)
+  {
+    if (!atom)
+      return 0.0;
+
+    // Honor explicit per-atom custom radius overrides when present;
+    // otherwise use Open Babel's element vdW radius table.
+    if (atom->customRadius() > 0.0)
+      return atom->customRadius();
+
+    // Avogadro's current Open Babel dependency provides OBElements::GetVdwRad().
+    return OpenBabel::OBElements::GetVdwRad(atom->atomicNumber());
+  }
+
+  static inline void appendAtomIfNew(QList<Atom*> *atoms, QSet<Atom*> *seen,
+                                     Atom *atom)
+  {
+    if (atom && !seen->contains(atom)) {
+      seen->insert(atom);
+      atoms->append(atom);
+    }
+  }
+
+  static inline QList<Atom*> atomsForVdwRadius(Molecule *mol, GLWidget *widget)
+  {
+    QList<Atom*> atoms;
+    QSet<Atom*> seen;
+
+    if (widget) {
+      PrimitiveList selectedPrimitives = widget->selectedPrimitives();
+
+      foreach(Primitive *primitive, selectedPrimitives.subList(Primitive::AtomType))
+        appendAtomIfNew(&atoms, &seen, static_cast<Atom*>(primitive));
+
+      foreach(Primitive *primitive, selectedPrimitives.subList(Primitive::BondType)) {
+        Bond *bond = static_cast<Bond*>(primitive);
+        appendAtomIfNew(&atoms, &seen, bond->beginAtom());
+        appendAtomIfNew(&atoms, &seen, bond->endAtom());
+      }
+    }
+
+    if (atoms.isEmpty() && mol)
+      atoms = mol->atoms();
+
+    return atoms;
+  }
+
+  static inline double vdwEnclosingRadius(const QList<Atom*> &atoms)
+  {
+    if (atoms.isEmpty())
+      return 0.0;
+
+    // This is an arithmetic-center enclosing radius: it is the maximum
+    // distance from the selected atoms' geometric center to their vdW surfaces.
+    // It is not a minimum enclosing sphere and not a vdW volume or
+    // equivalent-volume radius.
+    Eigen::Vector3d center = Eigen::Vector3d::Zero();
+    int atomCount = 0;
+    foreach(Atom *atom, atoms) {
+      if (!atom || !atom->pos())
+        continue;
+
+      center += *atom->pos();
+      ++atomCount;
+    }
+
+    if (!atomCount)
+      return 0.0;
+
+    center /= static_cast<double>(atomCount);
+
+    double radius = 0.0;
+    foreach(Atom *atom, atoms) {
+      if (!atom || !atom->pos())
+        continue;
+
+      radius = qMax(radius, (*atom->pos() - center).norm() + atomVdwRadius(atom));
+    }
+
+    return radius;
+  }
+
+} // namespace MolecularProperties
+} // namespace Avogadro
+
+#endif // VDWRADIUSCALCULATOR_H

--- a/libavogadro/src/glwidget.cpp
+++ b/libavogadro/src/glwidget.cpp
@@ -2031,7 +2031,10 @@ namespace Avogadro {
     d->molecule = molecule;
 
     // Clear the selection list
+    bool selectionDidChange = !d->selectedPrimitives.isEmpty();
     d->selectedPrimitives.clear();
+    if (selectionDidChange)
+      emit selectionChanged();
 
     // compute the molecule's geometric info
     updateGeometry();
@@ -2059,9 +2062,12 @@ namespace Avogadro {
 
   void GLWidget::unselectPrimitive(Primitive *p)
   {
+    bool selectionDidChange = d->selectedPrimitives.contains(p);
     d->selectedPrimitives.removeAll( p );
     // The engine caches must be invalidated
     d->updateCache = true;
+    if (selectionDidChange)
+      emit selectionChanged();
 
     // TODO: remove also from named selections
   }
@@ -2477,15 +2483,22 @@ namespace Avogadro {
 
   void GLWidget::setSelected(PrimitiveList primitives, bool select)
   {
+    bool selectionDidChange = false;
     foreach(Primitive *item, primitives) {
-      if (select && !d->selectedPrimitives.contains(item))
-          d->selectedPrimitives.append( item );
-      else if (!select)
+      if (select && !d->selectedPrimitives.contains(item)) {
+        d->selectedPrimitives.append( item );
+        selectionDidChange = true;
+      }
+      else if (!select && d->selectedPrimitives.contains(item)) {
         d->selectedPrimitives.removeAll( item );
+        selectionDidChange = true;
+      }
       // The engine caches must be invalidated
       d->updateCache = true;
       //      item->update();
     }
+    if (selectionDidChange)
+      emit selectionChanged();
   }
 
   PrimitiveList GLWidget::selectedPrimitives() const
@@ -2495,44 +2508,65 @@ namespace Avogadro {
 
   void GLWidget::toggleSelected( PrimitiveList primitives )
   {
+    bool selectionDidChange = false;
     foreach(Primitive *item, primitives)
     {
-      if (d->selectedPrimitives.contains(item))
+      if (d->selectedPrimitives.contains(item)) {
         d->selectedPrimitives.removeAll( item );
-      else
+        selectionDidChange = true;
+      }
+      else {
         d->selectedPrimitives.append(item);
+        selectionDidChange = true;
+      }
     }
     // The engine caches must be invalidated
     d->updateCache = true;
+    if (selectionDidChange)
+      emit selectionChanged();
   }
 
   void GLWidget::toggleSelected()
   {
     if (!d->molecule) return;
+    bool selectionDidChange = false;
     // Currently handle atoms and bonds
     foreach(Atom *a, d->molecule->atoms()) {
       Primitive *p = static_cast<Primitive *>(a);
-      if (d->selectedPrimitives.contains(p))
+      if (d->selectedPrimitives.contains(p)) {
         d->selectedPrimitives.removeAll(p);
-      else
+        selectionDidChange = true;
+      }
+      else {
         d->selectedPrimitives.append(p);
+        selectionDidChange = true;
+      }
     }
     foreach(Bond *b, d->molecule->bonds()) {
       Primitive *p = static_cast<Primitive *>(b);
-      if (d->selectedPrimitives.contains(p))
+      if (d->selectedPrimitives.contains(p)) {
         d->selectedPrimitives.removeAll(p);
-      else
+        selectionDidChange = true;
+      }
+      else {
         d->selectedPrimitives.append(p);
+        selectionDidChange = true;
+      }
     }
     // The engine caches must be invalidated
     d->updateCache = true;
+    if (selectionDidChange)
+      emit selectionChanged();
   }
 
   void GLWidget::clearSelected()
   {
+    bool selectionDidChange = !d->selectedPrimitives.isEmpty();
     d->selectedPrimitives.clear();
     // The engine caches must be invalidated
     d->updateCache = true;
+    if (selectionDidChange)
+      emit selectionChanged();
   }
 
   bool GLWidget::isSelected( const Primitive *p ) const

--- a/libavogadro/src/glwidget.h
+++ b/libavogadro/src/glwidget.h
@@ -882,6 +882,11 @@ namespace Avogadro {
       void namedSelectionsChanged();
 
       /**
+       * Signal that the selected primitives have changed.
+       */
+      void selectionChanged();
+
+      /**
        * Signal that this GLWidget was activated.
        */
       void activated(GLWidget *);

--- a/libavogadro/tests/CMakeLists.txt
+++ b/libavogadro/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
   ${libavogadro_BINARY_DIR}/src
   ${libavogadro_BINARY_DIR}/src/extensions
+  ${CMAKE_SOURCE_DIR}/libavogadro/src/extensions
   $<$<BOOL:${EIGEN3_FOUND}>:${EIGEN3_INCLUDE_DIR}>
   $<$<NOT:$<BOOL:${EIGEN3_FOUND}>>:${EIGEN2_INCLUDE_DIR}>
   ${OPENBABEL2_INCLUDE_DIR}
@@ -43,6 +44,7 @@ set(tests
   moleculefile
   neighborlist
   addremovehydrogens
+  vdwradius
 )
 if(XTB_FOUND)
   list(APPEND tests xtbopttool xtbphysics)

--- a/libavogadro/tests/vdwradiustest.cpp
+++ b/libavogadro/tests/vdwradiustest.cpp
@@ -1,0 +1,257 @@
+/**********************************************************************
+  VdwRadiusTest - Unit tests for Molecular Properties vdW radius helpers
+
+  This file is part of the Avogadro molecular editor project.
+  For more information, see <http://avogadro.cc/>
+ **********************************************************************/
+
+#include "config.h"
+
+#include <QtTest>
+#include <QSurfaceFormat>
+
+#include <avogadro/atom.h>
+#include <avogadro/bond.h>
+#include <avogadro/glwidget.h>
+#include <avogadro/molecule.h>
+#include <avogadro/primitivelist.h>
+
+#include "vdwradiuscalculator.h"
+
+#include <openbabel/elements.h>
+
+#include <Eigen/Core>
+
+using Avogadro::Atom;
+using Avogadro::Bond;
+using Avogadro::GLWidget;
+using Avogadro::Molecule;
+using Avogadro::Primitive;
+using Avogadro::PrimitiveList;
+using Eigen::Vector3d;
+
+class VdwRadiusTest : public QObject
+{
+  Q_OBJECT
+
+private:
+  static void compareRadius(double actual, double expected,
+                            double tolerance = 1.0e-6)
+  {
+    QVERIFY2(qAbs(actual - expected) < tolerance,
+             qPrintable(QString("Expected %1, got %2")
+                        .arg(expected, 0, 'f', 6)
+                        .arg(actual, 0, 'f', 6)));
+  }
+
+  static void setCarbonRadius(Atom *atom)
+  {
+    atom->setCustomRadius(1.70);
+  }
+
+  static void setHydrogenRadius(Atom *atom)
+  {
+    atom->setCustomRadius(1.20);
+  }
+
+  static Molecule *createIdealizedMethane(Bond **chBond = 0)
+  {
+    Molecule *molecule = new Molecule;
+    Atom *carbon = molecule->addAtom(6, Vector3d(0.0, 0.0, 0.0));
+    setCarbonRadius(carbon);
+
+    const double ch = 1.09;
+    Atom *hydrogen1 = molecule->addAtom(1, Vector3d(ch, ch, ch).normalized() * ch);
+    Atom *hydrogen2 = molecule->addAtom(1, Vector3d(ch, -ch, -ch).normalized() * ch);
+    Atom *hydrogen3 = molecule->addAtom(1, Vector3d(-ch, ch, -ch).normalized() * ch);
+    Atom *hydrogen4 = molecule->addAtom(1, Vector3d(-ch, -ch, ch).normalized() * ch);
+    setHydrogenRadius(hydrogen1);
+    setHydrogenRadius(hydrogen2);
+    setHydrogenRadius(hydrogen3);
+    setHydrogenRadius(hydrogen4);
+
+    Bond *bond = molecule->addBond(carbon, hydrogen1, 1);
+    molecule->addBond(carbon, hydrogen2, 1);
+    molecule->addBond(carbon, hydrogen3, 1);
+    molecule->addBond(carbon, hydrogen4, 1);
+
+    if (chBond)
+      *chBond = bond;
+
+    return molecule;
+  }
+
+private slots:
+  void singleCarbonAtom();
+  void twoCarbons();
+  void openBabelVdwLookup();
+  void customRadiusOverridesOpenBabel();
+  void idealizedMethaneWholeMolecule();
+  void methaneCarbonHydrogenBondSelection();
+  void waterWholeMolecule();
+  void fallbackToWholeMolecule();
+  void bondSelectionDeduplicatesAtoms();
+  void glWidgetSelectionChangedSignal();
+};
+
+void VdwRadiusTest::singleCarbonAtom()
+{
+  Molecule molecule;
+  Atom *carbon = molecule.addAtom(6, Vector3d(0.0, 0.0, 0.0));
+  setCarbonRadius(carbon);
+
+  QList<Atom*> atoms;
+  atoms.append(carbon);
+
+  compareRadius(Avogadro::MolecularProperties::vdwEnclosingRadius(atoms), 1.700);
+}
+
+void VdwRadiusTest::twoCarbons()
+{
+  Molecule molecule;
+  Atom *carbon1 = molecule.addAtom(6, Vector3d(-1.0, 0.0, 0.0));
+  Atom *carbon2 = molecule.addAtom(6, Vector3d(1.0, 0.0, 0.0));
+  setCarbonRadius(carbon1);
+  setCarbonRadius(carbon2);
+
+  QList<Atom*> atoms;
+  atoms.append(carbon1);
+  atoms.append(carbon2);
+
+  compareRadius(Avogadro::MolecularProperties::vdwEnclosingRadius(atoms), 2.700);
+}
+
+void VdwRadiusTest::openBabelVdwLookup()
+{
+  Molecule molecule;
+  Atom *carbon = molecule.addAtom(6, Vector3d(0.0, 0.0, 0.0));
+
+  compareRadius(Avogadro::MolecularProperties::atomVdwRadius(carbon),
+                OpenBabel::OBElements::GetVdwRad(6));
+}
+
+void VdwRadiusTest::customRadiusOverridesOpenBabel()
+{
+  Molecule molecule;
+  Atom *carbon = molecule.addAtom(6, Vector3d(0.0, 0.0, 0.0));
+  carbon->setCustomRadius(2.34);
+
+  compareRadius(Avogadro::MolecularProperties::atomVdwRadius(carbon), 2.34);
+}
+
+void VdwRadiusTest::idealizedMethaneWholeMolecule()
+{
+  Molecule *molecule = createIdealizedMethane();
+  QList<Atom*> atoms = Avogadro::MolecularProperties::atomsForVdwRadius(molecule, 0);
+
+  compareRadius(Avogadro::MolecularProperties::vdwEnclosingRadius(atoms), 2.290);
+  delete molecule;
+}
+
+void VdwRadiusTest::methaneCarbonHydrogenBondSelection()
+{
+  Bond *bond = 0;
+  Molecule *molecule = createIdealizedMethane(&bond);
+  {
+    GLWidget widget(molecule, QSurfaceFormat());
+
+    PrimitiveList selected;
+    selected.append(static_cast<Primitive*>(bond));
+    widget.setSelected(selected, true);
+
+    QList<Atom*> atoms = Avogadro::MolecularProperties::atomsForVdwRadius(molecule, &widget);
+    QCOMPARE(atoms.size(), 2);
+    compareRadius(Avogadro::MolecularProperties::vdwEnclosingRadius(atoms), 2.245);
+  }
+
+  delete molecule;
+}
+
+void VdwRadiusTest::waterWholeMolecule()
+{
+  Molecule molecule;
+  Atom *oxygen = molecule.addAtom(8, Vector3d(0.000000, 0.000000, 0.000000));
+  Atom *hydrogen1 = molecule.addAtom(1, Vector3d(0.957200, 0.000000, 0.000000));
+  Atom *hydrogen2 = molecule.addAtom(1, Vector3d(-0.239987, 0.926627, 0.000000));
+  oxygen->setCustomRadius(1.52);
+  setHydrogenRadius(hydrogen1);
+  setHydrogenRadius(hydrogen2);
+
+  QList<Atom*> atoms;
+  atoms.append(oxygen);
+  atoms.append(hydrogen1);
+  atoms.append(hydrogen2);
+
+  compareRadius(Avogadro::MolecularProperties::vdwEnclosingRadius(atoms),
+                1.982, 1.0e-3);
+}
+
+void VdwRadiusTest::fallbackToWholeMolecule()
+{
+  Molecule *molecule = createIdealizedMethane();
+  QList<Atom*> atoms = Avogadro::MolecularProperties::atomsForVdwRadius(molecule, 0);
+  QCOMPARE(atoms.size(), 5);
+
+  {
+    GLWidget widget(molecule, QSurfaceFormat());
+    atoms = Avogadro::MolecularProperties::atomsForVdwRadius(molecule, &widget);
+    QCOMPARE(atoms.size(), 5);
+  }
+
+  delete molecule;
+}
+
+void VdwRadiusTest::bondSelectionDeduplicatesAtoms()
+{
+  Molecule molecule;
+  Atom *carbon1 = molecule.addAtom(6, Vector3d(0.0, 0.0, 0.0));
+  Atom *carbon2 = molecule.addAtom(6, Vector3d(1.0, 0.0, 0.0));
+  Bond *bond = molecule.addBond(carbon1, carbon2, 1);
+  GLWidget widget(&molecule, QSurfaceFormat());
+
+  PrimitiveList selected;
+  selected.append(static_cast<Primitive*>(carbon1));
+  selected.append(static_cast<Primitive*>(bond));
+  widget.setSelected(selected, true);
+
+  QList<Atom*> atoms = Avogadro::MolecularProperties::atomsForVdwRadius(&molecule, &widget);
+  QCOMPARE(atoms.size(), 2);
+  QVERIFY(atoms.contains(carbon1));
+  QVERIFY(atoms.contains(carbon2));
+}
+
+void VdwRadiusTest::glWidgetSelectionChangedSignal()
+{
+  Molecule molecule;
+  Atom *carbon1 = molecule.addAtom(6, Vector3d(0.0, 0.0, 0.0));
+  Atom *carbon2 = molecule.addAtom(6, Vector3d(1.0, 0.0, 0.0));
+  GLWidget widget(&molecule, QSurfaceFormat());
+  QSignalSpy spy(&widget, SIGNAL(selectionChanged()));
+
+  PrimitiveList selection;
+  selection.append(static_cast<Primitive*>(carbon1));
+  widget.setSelected(selection, true);
+  QCOMPARE(spy.count(), 1);
+
+  // Selecting the already-selected atom does not change the selection.
+  widget.setSelected(selection, true);
+  QCOMPARE(spy.count(), 1);
+
+  widget.toggleSelected(selection);
+  QCOMPARE(spy.count(), 2);
+
+  PrimitiveList secondSelection;
+  secondSelection.append(static_cast<Primitive*>(carbon2));
+  widget.setSelected(secondSelection, true);
+  QCOMPARE(spy.count(), 3);
+
+  widget.toggleSelected();
+  QCOMPARE(spy.count(), 4);
+
+  widget.clearSelected();
+  QCOMPARE(spy.count(), 5);
+}
+
+QTEST_MAIN(VdwRadiusTest)
+
+#include "moc_vdwradiustest.cpp"


### PR DESCRIPTION
### Motivation
- Provide a van der Waals enclosing radius in the Molecule Properties dialog that reflects either the whole molecule or the current selection. 
- Update the properties dialog dynamically when the GL selection changes so the value reflects the selected primitives. 
- Centralize vdW radius logic in a small helper so it can be tested and reused.

### Description
- Added `vdwradiuscalculator.h` with `atomVdwRadius`, `atomsForVdwRadius`, and `vdwEnclosingRadius` helpers in `Avogadro::MolecularProperties` to compute an arithmetic-center vdW enclosing radius and to gather atoms from a `GLWidget` selection. 
- Updated the properties UI (`molecularpropdialog.ui`) to include a `vdW Enclosing Radius (Å)` label and tooltip and corresponding `vdwRadiusLine` output. 
- Modified `MolecularPropertiesExtension` to track the active `GLWidget` (`m_widget`), connect `selectionChanged()` to a new slot `updateVdwRadius()`, and call `updateVdwRadius()` during `update()` so the dialog shows selection-aware values. 
- Added a `selectionChanged()` signal to `GLWidget` and emitted it when selection state actually changes (`setSelected`, `toggleSelected`, `toggleSelected()` overload, `unselectPrimitive`, `clearSelected`, and when `setMolecule` clears a prior selection). 
- Added unit tests `vdwradiustest.cpp` and included it in `tests/CMakeLists.txt` to validate radius calculations, custom-radius overrides, selection handling, and the `selectionChanged` signal behavior.

### Testing
- Added and ran the new unit test `vdwradius` (`vdwradiustest.cpp`) which exercises `atomVdwRadius`, `vdwEnclosingRadius`, `atomsForVdwRadius`, selection behavior, and the `selectionChanged` signal; all assertions passed. 
- The test suite includes signal-based checks using `QSignalSpy` to verify `selectionChanged()` is emitted only on actual selection changes, and those checks succeeded. 
- No other automated tests were modified and the added test was integrated via `tests/CMakeLists.txt` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1897f105748333b9196efde7cb13e4)